### PR TITLE
Skip and log clipping failures

### DIFF
--- a/src/main/scala/vectorpipe/Clip.scala
+++ b/src/main/scala/vectorpipe/Clip.scala
@@ -1,6 +1,7 @@
 package vectorpipe
 
 import scala.collection.mutable.ListBuffer
+import scala.util.{Try, Success, Failure}
 
 import geotrellis.proj4.{LatLng, WebMercator}
 import geotrellis.vector._
@@ -73,23 +74,18 @@ object Clip {
     centre.distanceToSegment(p1, p2) <= radius
 
   /** Naively clips Features to fit the given Extent. */
-  def byExtent[G <: Geometry, D](extent: Extent, f: Feature[G, D]): Feature[Geometry, D] = {
+  def byExtent[G <: Geometry, D](extent: Extent, f: Feature[G, D]): Either[String, Feature[Geometry, D]] = {
     val exPoly: Polygon = extent.toPolygon
 
-    val geom: Geometry = try {
-      f.geom match {
-        case mp: MultiPolygon => MultiPolygon(mp.polygons.flatMap(_.intersection(exPoly).as[Polygon]))
-        case _ => f.geom.intersection(exPoly).toGeometry.get
-      }
-    } catch {
-      case e: Throwable => {
-        println(s"${f.data}: ${f.geom.reproject(WebMercator, LatLng).toGeoJson}")
-
-        throw e
-      }
+    val clipped: Try[Geometry] = f.geom match {
+      case mp: MultiPolygon => Try(MultiPolygon(mp.polygons.flatMap(_.intersection(exPoly).as[Polygon])))
+      case _ => Try(f.geom.intersection(exPoly).toGeometry.get)
     }
 
-    Feature(geom, f.data)
+    clipped match {
+      case Failure(_) => Left(s"${f.data}: ${f.geom.reproject(WebMercator, LatLng).toGeoJson}")
+      case Success(g) => Right(Feature(g, f.data))
+    }
   }
 
   /** Clips Features to a 3x3 grid surrounding the current Tile.
@@ -97,17 +93,17 @@ object Clip {
     * outside their original Tile, and helps avoid the pain of
     * restitching later.
     */
-  def byBufferedExtent[G <: Geometry, D](extent: Extent, f: Feature[G, D]): Feature[Geometry, D] =
+  def byBufferedExtent[G <: Geometry, D](extent: Extent, f: Feature[G, D]): Either[String, Feature[Geometry, D]] =
     byExtent(extent.expandBy(extent.width, extent.height), f)
 
   /** Bias the clipping strategy based on the incoming [[Geometry]]. */
-  def byHybrid[G <: Geometry, D](extent: Extent, f: Feature[G, D]): Feature[Geometry, D] = f.geom match {
-    case pnt: Point => f  /* A `Point` will always fall within the Extent */
-    case line: Line => Feature(toNearestPoint(extent, line), f.data)
+  def byHybrid[G <: Geometry, D](extent: Extent, f: Feature[G, D]): Either[String, Feature[Geometry, D]] = f.geom match {
+    case pnt: Point => Right(f)  /* A `Point` will always fall within the Extent */
+    case line: Line => Right(Feature(toNearestPoint(extent, line), f.data))
     case poly: Polygon => byBufferedExtent(extent, f)
     case mply: MultiPolygon => byBufferedExtent(extent, f)
   }
 
   /** Yield an [[Feature]] as-is. */
-  def asIs[G <: Geometry, D](extent: Extent, f: Feature[G, D]): Feature[G, D] = f
+  def asIs[G <: Geometry, D](extent: Extent, f: Feature[G, D]): Either[String, Feature[G, D]] = Right(f)
 }

--- a/src/main/scala/vectorpipe/VectorPipe.scala
+++ b/src/main/scala/vectorpipe/VectorPipe.scala
@@ -7,6 +7,7 @@ import geotrellis.spark.tiling._
 import geotrellis.vector._
 import geotrellis.vector.io._
 import geotrellis.vectortile.VectorTile
+import org.apache.log4j.Logger
 import org.apache.spark.rdd._
 
 // --- //
@@ -183,11 +184,16 @@ object VectorPipe {
     rdd.map({ case (k, iter) => (k, collate(mt(k), iter))})
   }
 
-  /** Print any clipping errors to STDOUT - to be passed to [[toGrid]]. */
-  def stdout[G <: Geometry, D](e: Extent, f: Feature[G, D]): Unit = {
-    println(s"CLIP FAILURE W/ EXTENT: ${e}\nELEMENT METADATA: ${f.data}\nGEOM: ${f.geom.reproject(WebMercator, LatLng).toGeoJson}")
-  }
+  private def logString[G <: Geometry, D](e: Extent, f: Feature[G, D]): String =
+    s"CLIP FAILURE W/ EXTENT: ${e}\nELEMENT METADATA: ${f.data}\nGEOM: ${f.geom.reproject(WebMercator, LatLng).toGeoJson}"
 
-  /** Don't log clipping failures. */
+  /** Print any clipping errors to STDOUT - to be passed to [[toGrid]]. */
+  def stdout[G <: Geometry, D](e: Extent, f: Feature[G, D]): Unit = println(logString(e, f))
+
+  /** Log a clipping error as an ERROR through Spark's default log4j - to be passed to [[toGrid]]. */
+  def log4j[G <: Geometry, D](e: Extent, f: Feature[G, D]): Unit =
+    Logger.getRootLogger().error(logString(e, f))
+
+  /** Don't log clipping failures - to be passed to [[toGrid]]. */
   def ignore[G <: Geometry, D](e: Extent, f: Feature[G, D]): Unit = Unit
 }

--- a/src/main/scala/vectorpipe/VectorPipe.scala
+++ b/src/main/scala/vectorpipe/VectorPipe.scala
@@ -187,4 +187,7 @@ object VectorPipe {
   def stdout[G <: Geometry, D](e: Extent, f: Feature[G, D]): Unit = {
     println(s"CLIP FAILURE W/ EXTENT: ${e}\nELEMENT METADATA: ${f.data}\nGEOM: ${f.geom.reproject(WebMercator, LatLng).toGeoJson}")
   }
+
+  /** Don't log clipping failures. */
+  def ignore[G <: Geometry, D](e: Extent, f: Feature[G, D]): Unit = Unit
 }

--- a/src/main/tut/usage/concepts.md
+++ b/src/main/tut/usage/concepts.md
@@ -71,6 +71,11 @@ on which clipping function you choose (from the `vectorpipe.Clip` object, or
 even your own custom one) the shape of the clipped Geometry will vary. See
 our Scaladocs for more detail on the available options.
 
+Admittedly, we sometimes can't guarantee the validity of incoming vector data.
+Clipping is known to occasionally fail on large, complex multipolygons, so
+we skip over these failures while optionally allowing to log them. Any logging
+framework can be used.
+
 ### Collation Functions
 
 Once clipped and gridded by `VectorPipe.toGrid`, we have a `RDD[(SpatialKey,

--- a/src/main/tut/usage/usage.md
+++ b/src/main/tut/usage/usage.md
@@ -33,7 +33,7 @@ val features: RDD[osm.OSMFeature] =
 
 /* All Geometries clipped to your `layout` grid */
 val featGrid: RDD[(SpatialKey, Iterable[osm.OSMFeature])] =
-  VectorPipe.toGrid(Clip.byHybrid, layout, features)
+  VectorPipe.toGrid(Clip.byHybrid, osm.stdout, layout, features)
 
 /* A grid of Vector Tiles */
 val tiles: RDD[(SpatialKey, VectorTile)] =


### PR DESCRIPTION
### TODO

- [x] `toGrid` expects `clip` function to return an ~~`Either`~~ `Option`
- [x] Built-in clipping functions yield `Either`
- ~~Log any `Left`s given from clipping~~ (logging is now framework agnostic)
- [x] Make logging "framework agnostic" and provide sensible defaults 

### Motivation

We've decided to assume that exotic, non-cooperative geometries will always exist within OSM data. Rather than crash the whole ingest when one of these is encountered, this PR allows for these to be skipped over and logged. It should be possible to log any `Left` values encountered without incurring too much invasive `IO` - hopefully transfer of the failure string to the driver or a write to S3 will be enough.

**Question:** If we naively print a logging statement via each executor, will those be aggregated into the EMR log file already written to S3?

**Question:** Where to print the errors in the local case? It would be nice if a single solution took care of both the local and EMR cases.

Ping @lossyrob  