### PR TITLE
Add logging to `toFeatures`

### DIFF
--- a/src/main/scala/vectorpipe/VectorPipe.scala
+++ b/src/main/scala/vectorpipe/VectorPipe.scala
@@ -113,12 +113,9 @@ object VectorPipe {
     * @param clip A function which represents a "clipping strategy".
     * @param logError An IO function that will log any clipping failures.
     */
-  def toGrid[G <: Geometry, D](
-    clip: (Extent, Feature[G, D]) => Option[Feature[G, D]],
-    logError: (Extent, Feature[G, D]) => Unit,
-    ld: LayoutDefinition,
-    rdd: RDD[Feature[G, D]]
-  ): RDD[(SpatialKey, Iterable[Feature[G, D]])] = {
+  def toGrid[G <: Geometry, D](ld: LayoutDefinition, rdd: RDD[Feature[G, D]])
+            (clip: (Extent, Feature[G, D]) => Option[Feature[G, D]])
+            (logError: (((Extent, Feature[G, D])) => String) => ((Extent, Feature[G, D])) => Unit): RDD[(SpatialKey, Iterable[Feature[G, D]])] = {
 
     val mt: MapKeyTransform = ld.mapTransform
 
@@ -132,6 +129,11 @@ object VectorPipe {
     /* Associate each Feature with a SpatialKey */
     val grid: RDD[(SpatialKey, Feature[G, D])] = rdd.flatMap(f => byIntersect(mt, f))
 
+    /** A way to render some Geometry that failed to clip. */
+    val errorClipping: ((Extent, Feature[G, D])) => String = { case (e, f) =>
+      s"CLIP FAILURE W/ EXTENT: ${e}\nELEMENT METADATA: ${f.data}\nGEOM: ${f.geom.reproject(WebMercator, LatLng).toGeoJson}"
+    }
+
     grid.groupByKey().map { case (k, iter) =>
       val kExt: Extent = mt(k)
 
@@ -139,7 +141,7 @@ object VectorPipe {
       val clipped: List[Feature[G, D]] = iter.foldLeft(List.empty[Feature[G, D]]) { (acc, g) =>
         clip(kExt, g) match {
           case Some(h) => h :: acc
-          case None => logError(kExt, g); acc /* Sneaky IO to log the error */
+          case None => logError(errorClipping)((kExt, g)); acc /* Sneaky IO to log the error */
         }
       }
 
@@ -174,26 +176,22 @@ object VectorPipe {
     *
     * @see [[vectorpipe.Collate]]
     */
-  def toVectorTile[G <: Geometry, D](
-    collate: (Extent, Iterable[Feature[G, D]]) => VectorTile,
-    ld: LayoutDefinition,
-    rdd: RDD[(SpatialKey, Iterable[Feature[G, D]])]
-  ): RDD[(SpatialKey, VectorTile)] = {
+  def toVectorTile[G <: Geometry, D](ld: LayoutDefinition, rdd: RDD[(SpatialKey, Iterable[Feature[G, D]])])
+                  (collate: (Extent, Iterable[Feature[G, D]]) => VectorTile): RDD[(SpatialKey, VectorTile)] = {
     val mt: MapKeyTransform = ld.mapTransform
 
     rdd.map({ case (k, iter) => (k, collate(mt(k), iter))})
   }
 
-  private def logString[G <: Geometry, D](e: Extent, f: Feature[G, D]): String =
-    s"CLIP FAILURE W/ EXTENT: ${e}\nELEMENT METADATA: ${f.data}\nGEOM: ${f.geom.reproject(WebMercator, LatLng).toGeoJson}"
 
-  /** Print any clipping errors to STDOUT - to be passed to [[toGrid]]. */
-  def stdout[G <: Geometry, D](e: Extent, f: Feature[G, D]): Unit = println(logString(e, f))
 
-  /** Log a clipping error as an ERROR through Spark's default log4j - to be passed to [[toGrid]]. */
-  def log4j[G <: Geometry, D](e: Extent, f: Feature[G, D]): Unit =
-    Logger.getRootLogger().error(logString(e, f))
+  /** Log an error to STDOUT. */
+  def logToStdout[A](f: A => String): A => Unit = { a => println(f(a)) }
 
-  /** Don't log clipping failures - to be passed to [[toGrid]]. */
-  def ignore[G <: Geometry, D](e: Extent, f: Feature[G, D]): Unit = Unit
+  /** Log an error as an ERROR through Spark's default log4j. */
+  def logToLog4j[A](f: A => String): A => Unit = { a => Logger.getRootLogger().error(f(a)) }
+
+  /** Skip over some failure. */
+  def logNothing[A](f: A => String): A => Unit = { _ => Unit }
+
 }

--- a/src/main/scala/vectorpipe/osm/Element.scala
+++ b/src/main/scala/vectorpipe/osm/Element.scala
@@ -12,7 +12,7 @@ sealed trait Element {
   def data: ElementData
 }
 
-object Element {
+private[vectorpipe] object Element {
   implicit val elementMeta: Parser[ElementMeta] = (
     Parser.forMandatoryAttribute("id").map(_.toLong) ~
     Parser.forOptionalAttribute("user").map(_.getOrElse("anonymous")) ~

--- a/src/main/scala/vectorpipe/osm/internal/ElementToFeature.scala
+++ b/src/main/scala/vectorpipe/osm/internal/ElementToFeature.scala
@@ -118,7 +118,8 @@ private[vectorpipe] object ElementToFeature {
   def multipolygons(
     lines: RDD[OSMLine],
     polys: RDD[OSMPolygon],
-    relations: RDD[Relation]
+    relations: RDD[Relation],
+    logError: Feature[Line, ElementData] => Unit
   ): (RDD[OSMMultiPoly], RDD[OSMLine], RDD[OSMPolygon]) = {
     // filter out polys that are used in relations
     // merge RDDs back together
@@ -154,7 +155,8 @@ private[vectorpipe] object ElementToFeature {
         /* All line segments which could fuse into Polygons */
         val (unfusedLines, fusedLines) = fuseLines(sorted).run(List.empty).value
 
-        // if (dumpedLineCount > 0) println(s"LINES DUMPED BY fuseLines: ${dumpedLineCount}")
+        /* Log each `Line` which failed to fuse */
+        unfusedLines.foreach(logError)
 
         val ps: Vector[OSMPolygon] = gs.flatMap({
           case Left(p) => Some(p)

--- a/src/main/scala/vectorpipe/osm/internal/ElementToFeature.scala
+++ b/src/main/scala/vectorpipe/osm/internal/ElementToFeature.scala
@@ -121,8 +121,12 @@ private[vectorpipe] object ElementToFeature {
   private def errorFusing(f: OSMLine): String =
     s"LINE FUSION FAILURE\nELEMENT METADATA: ${f.data}\nGEOM: ${f.geom.reproject(WebMercator, LatLng).toGeoJson}"
 
-  def multipolygons(lines: RDD[OSMLine], polys: RDD[OSMPolygon], relations: RDD[Relation])
-                   (logError: (OSMLine => String) => (OSMLine => Unit)): (RDD[OSMMultiPoly], RDD[OSMLine], RDD[OSMPolygon]) = {
+  def multipolygons(
+    logError: (OSMLine => String) => OSMLine => Unit,
+    lines: RDD[OSMLine],
+    polys: RDD[OSMPolygon],
+    relations: RDD[Relation]
+  ): (RDD[OSMMultiPoly], RDD[OSMLine], RDD[OSMPolygon]) = {
     // filter out polys that are used in relations
     // merge RDDs back together
     val relLinks: RDD[(Long, Relation)] =

--- a/src/main/scala/vectorpipe/osm/internal/ElementToFeature.scala
+++ b/src/main/scala/vectorpipe/osm/internal/ElementToFeature.scala
@@ -152,7 +152,7 @@ private[vectorpipe] object ElementToFeature {
           spatialSort(ls.map(f => (f.geom.centroid.as[Point].get, f))).map(_._2)
 
         /* All line segments which could fuse into Polygons */
-        val (dumpedLineCount, fusedLines) = fuseLines(sorted).run(0).value
+        val (unfusedLines, fusedLines) = fuseLines(sorted).run(List.empty).value
 
         // if (dumpedLineCount > 0) println(s"LINES DUMPED BY fuseLines: ${dumpedLineCount}")
 
@@ -256,7 +256,7 @@ private[vectorpipe] object ElementToFeature {
   }
 
   /* Code smell to massage the Applicative use below */
-  private type IntState[T] = State[Int, T]
+  private type LineState[T] = State[List[OSMLine], T]
 
   /**
    * ASSUMPTIONS:
@@ -271,32 +271,30 @@ private[vectorpipe] object ElementToFeature {
    * Note: The [[State]] monad usage here is for counting Lines which couldn't
    * be fused.
    */
-  private def fuseLines(v: Vector[OSMLine]): State[Int, Vector[OSMPolygon]] = v match {
-    case Vector() => Vector.empty.pure[IntState]
-    case v if v.length == 1 => State.modify[Int](_ + 1).map(_ => Vector.empty)
-    case v => {
-      fuseOne(v).flatMap({
-        case None => fuseLines(v.tail)
-        case Some((f, d, i, rest)) => {
-          if (f.isClosed)
-            fuseLines(rest).map(c => Feature(Polygon(f), d) +: c)
-          else {
-            /* The next sections of the currently accumulating Line may be far down
-             * the Vector, so we punt it forward to avoid wasted traversals
-             * and intersection checks.
-             * This is a band-aid around the fact that `spatialSort` doesn't
-             * place all sections of every fusable line in order; clumps of them
-             * can appear far apart in the Vector.
-             *
-             * If `i == 0`, the splitAt and `(++)` below are basically no-ops,
-             * so there's no point in any `if (i == 0) skipTheSplitAt`.
-             */
-            val (a, b) = rest.splitAt(i)
+  private def fuseLines(v: Vector[OSMLine]): State[List[OSMLine], Vector[OSMPolygon]] = v match {
+    case Vector()  => Vector.empty.pure[LineState]
+    case Vector(h) => State.modify[List[OSMLine]](h :: _).map(_ => Vector.empty)
+    case v => fuseOne(v) match {
+      case None => State.modify[List[OSMLine]](v.head :: _) >> fuseLines(v.tail)
+      case Some((f, d, i, rest)) => {
+        if (f.isClosed)
+          fuseLines(rest).map(c => Feature(Polygon(f), d) +: c)
+        else {
+          /* The next sections of the currently accumulating Line may be far down
+           * the Vector, so we punt it forward to avoid wasted traversals
+           * and intersection checks.
+           * This is a band-aid around the fact that `spatialSort` doesn't
+           * place all sections of every fusable line in order; clumps of them
+           * can appear far apart in the Vector.
+           *
+           * If `i == 0`, the splitAt and `(++)` below are basically no-ops,
+           * so there's no point in any `if (i == 0) skipTheSplitAt`.
+           */
+          val (a, b) = rest.splitAt(i)
 
-            fuseLines(a ++ (Feature(f, d) +: b))
-          }
+          fuseLines(a ++ (Feature(f, d) +: b))
         }
-      })
+      }
     }
   }
 
@@ -304,13 +302,11 @@ private[vectorpipe] object ElementToFeature {
    * Fuse the head Line in the Vector with the first other Line possible.
    * This borrows [[fuseLines]]'s assumptions.
    */
-  private def fuseOne(
-    v: Vector[OSMLine]
-  ): State[Int, Option[(Line, ElementData, Int, Vector[OSMLine])]] = {
+  private def fuseOne(v: Vector[OSMLine]): Option[(Line, ElementData, Int, Vector[OSMLine])] = {
     val h = v.head
     val t = v.tail
 
-    // TODO: Use a `while` instead?
+    // TODO: Use a `while` instead? Scala `for` is slow.
     for ((f, i) <- t.zipWithIndex) {
       if (h.geom.touches(f.geom)) { /* Found two lines that should fuse */
         val lm = new LineMerger /* from JTS */
@@ -322,16 +318,13 @@ private[vectorpipe] object ElementToFeature {
 
         val (a, b) = t.splitAt(i)
 
-        /* Hand-hold the typechecker */
-        val res: Option[(Line, ElementData, Int, Vector[OSMLine])] =
-          Some((line, h.data, i, a ++ b.tail))
-
         /* Return early */
-        return res.pure[IntState]
+        return Some((line, h.data, i, a ++ b.tail))
       }
     }
 
-    State.modify[Int](_ + 1).map(_ => None)
+    /* The line `h` didn't fuse! */
+    None
   }
 
   /** Is a given line illegal? */

--- a/src/main/scala/vectorpipe/osm/package.scala
+++ b/src/main/scala/vectorpipe/osm/package.scala
@@ -177,8 +177,12 @@ package object osm {
    *     across its child members. Otherwise, Relations are "dropped"
    *     from the output.
    */
-  def toFeatures(nodes: RDD[Node], ways: RDD[Way], relations: RDD[Relation])
-                (logError: (Feature[Line, ElementData] => String) => Feature[Line, ElementData] => Unit): RDD[OSMFeature] = {
+  def toFeatures(
+    logError: (Feature[Line, ElementData] => String) => Feature[Line, ElementData] => Unit,
+    nodes: RDD[Node],
+    ways: RDD[Way],
+    relations: RDD[Relation]
+  ): RDD[OSMFeature] = {
 
     /* All Geometric OSM Relations.
      * A (likely false) assumption made in the `flatTree` function is that
@@ -203,7 +207,7 @@ package object osm {
      */
     val simplePolys = rawPolys.filter(_.geom.isValid)
 
-    val (multiPolys, lines, polys) = E2F.multipolygons(rawLines, simplePolys, geomRelations)(logError)
+    val (multiPolys, lines, polys) = E2F.multipolygons(logError, rawLines, simplePolys, geomRelations)
 
     /* A trick to allow us to fuse the RDDs of various Geom types */
     val pnt: RDD[OSMFeature] = points.map(identity)

--- a/src/main/scala/vectorpipe/osm/package.scala
+++ b/src/main/scala/vectorpipe/osm/package.scala
@@ -176,7 +176,12 @@ package object osm {
    *     across its child members. Otherwise, Relations are "dropped"
    *     from the output.
    */
-  def toFeatures(nodes: RDD[Node], ways: RDD[Way], relations: RDD[Relation]): RDD[OSMFeature] = {
+  def toFeatures(
+    nodes: RDD[Node],
+    ways: RDD[Way],
+    relations: RDD[Relation],
+    logError: Feature[Line, ElementData] => Unit
+  ): RDD[OSMFeature] = {
 
     /* All Geometric OSM Relations.
      * A (likely false) assumption made in the `flatTree` function is that
@@ -201,7 +206,7 @@ package object osm {
      */
     val simplePolys = rawPolys.filter(_.geom.isValid)
 
-    val (multiPolys, lines, polys) = E2F.multipolygons(rawLines, simplePolys, geomRelations)
+    val (multiPolys, lines, polys) = E2F.multipolygons(rawLines, simplePolys, geomRelations, logError)
 
     /* A trick to allow us to fuse the RDDs of various Geom types */
     val pnt: RDD[OSMFeature] = points.map(identity)

--- a/src/main/scala/vectorpipe/osm/package.scala
+++ b/src/main/scala/vectorpipe/osm/package.scala
@@ -7,6 +7,7 @@ import scala.util.{ Failure, Success, Try }
 import geotrellis.proj4._
 import geotrellis.vector._
 import geotrellis.vector.io._
+import org.apache.log4j.Logger
 import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql._
@@ -216,5 +217,17 @@ package object osm {
 
     pnt ++ lns ++ pls ++ mps
   }
+
+  private def logString[G <: Geometry, D](f: Feature[G, D]): String =
+    s"LINE FUSION FAILURE\nELEMENT METADATA: ${f.data}\nGEOM: ${f.geom.reproject(WebMercator, LatLng).toGeoJson}"
+
+  /** Print line-fusion failures to STDOUT - to be passed to [[toFeatures]]. */
+  def stdout(f: Feature[Line, ElementData]): Unit = println(logString(f))
+
+  /** Log line-fusion failures as an ERROR through Spark's default log4j - to be passed to [[toFeatures]]. */
+  def log4j(f: Feature[Line, ElementData]): Unit = Logger.getRootLogger().error(logString(f))
+
+  /** Don't log any line-fusion failures - to be passed to [[toFeatures]]. */
+  def ignore(f: Feature[Line, ElementData]): Unit = Unit
 
 }

--- a/src/main/tut/usage/usage.md
+++ b/src/main/tut/usage/usage.md
@@ -29,7 +29,7 @@ val (nodes, ways, relations): (RDD[osm.Node], RDD[osm.Way], RDD[osm.Relation]) =
  * Note: type OSMFeature = Feature[Geometry, Tree[ElementData]]
  */
 val features: RDD[osm.OSMFeature] =
-  osm.toFeatures(nodes, ways, relations)
+  osm.toFeatures(nodes, ways, relations, osm.stdout)
 
 /* All Geometries clipped to your `layout` grid */
 val featGrid: RDD[(SpatialKey, Iterable[osm.OSMFeature])] =

--- a/src/main/tut/usage/usage.md
+++ b/src/main/tut/usage/usage.md
@@ -29,15 +29,15 @@ val (nodes, ways, relations): (RDD[osm.Node], RDD[osm.Way], RDD[osm.Relation]) =
  * Note: type OSMFeature = Feature[Geometry, Tree[ElementData]]
  */
 val features: RDD[osm.OSMFeature] =
-  osm.toFeatures(nodes, ways, relations, osm.stdout)
+  osm.toFeatures(nodes, ways, relations)(VectorPipe.logToStdout)
 
 /* All Geometries clipped to your `layout` grid */
 val featGrid: RDD[(SpatialKey, Iterable[osm.OSMFeature])] =
-  VectorPipe.toGrid(Clip.byHybrid, VectorPipe.stdout, layout, features)
+  VectorPipe.toGrid(layout, features)(Clip.byHybrid)(VectorPipe.logToStdout)
 
 /* A grid of Vector Tiles */
 val tiles: RDD[(SpatialKey, VectorTile)] =
-  VectorPipe.toVectorTile(Collate.byOSM, layout, featGrid)
+  VectorPipe.toVectorTile(layout, featGrid)(Collate.byOSM)
 
 /* Further processing here, writing to S3, etc. */
 

--- a/src/main/tut/usage/usage.md
+++ b/src/main/tut/usage/usage.md
@@ -29,15 +29,15 @@ val (nodes, ways, relations): (RDD[osm.Node], RDD[osm.Way], RDD[osm.Relation]) =
  * Note: type OSMFeature = Feature[Geometry, Tree[ElementData]]
  */
 val features: RDD[osm.OSMFeature] =
-  osm.toFeatures(nodes, ways, relations)(VectorPipe.logToStdout)
+  osm.toFeatures(VectorPipe.logToStdout, nodes, ways, relations)
 
 /* All Geometries clipped to your `layout` grid */
 val featGrid: RDD[(SpatialKey, Iterable[osm.OSMFeature])] =
-  VectorPipe.toGrid(layout, features)(Clip.byHybrid)(VectorPipe.logToStdout)
+  VectorPipe.toGrid(Clip.byHybrid, VectorPipe.logToStdout, layout, features)
 
 /* A grid of Vector Tiles */
 val tiles: RDD[(SpatialKey, VectorTile)] =
-  VectorPipe.toVectorTile(layout, featGrid)(Collate.byOSM)
+  VectorPipe.toVectorTile(Collate.byOSM, layout, featGrid)
 
 /* Further processing here, writing to S3, etc. */
 


### PR DESCRIPTION
### TODO

- [x] Log `Line` fusion failures
- [x] Provide cleaner logging function API

### Motivation

We were silently skipping over failures to fuse `Line`s together in the depths of `ElementToFeature`. This PR adds a customizable way to log those failures, as well as reworks the APIs of the library's primary functions.