### PR TITLE
Remove Ensime settings

### DIFF
--- a/ensime.sbt
+++ b/ensime.sbt
@@ -1,3 +1,0 @@
-ensimeIgnoreMissingDirectories in ThisBuild := true
-
-ensimeJavaFlags in ThisBuild := Seq("-Xmx6g")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,5 @@
 addSbtPlugin("com.47deg"  % "sbt-microsites" % "0.7.4")
 
 addSbtPlugin("com.scalapenos" % "sbt-prompt" % "1.0.2")
+
+addSbtPlugin("org.ensime" % "sbt-ensime" % "2.0.1")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,3 @@
 addSbtPlugin("com.47deg"  % "sbt-microsites" % "0.7.4")
 
 addSbtPlugin("com.scalapenos" % "sbt-prompt" % "1.0.2")
-
-addSbtPlugin("org.ensime" % "sbt-ensime" % "2.0.1")


### PR DESCRIPTION
Required for `sbt` subcommands to work appropriately with the configuration provided by `ensime.sbt`.

---

**Testing**

On `master`:

```
$ sbt publish-local
[info] Loading global plugins from /Users/hcastro/.sbt/0.13/plugins
[info] Loading project definition from /Users/hcastro/Projects/vectorpipe/project
[info] Updating {file:/Users/hcastro/Projects/vectorpipe/project/}vectorpipe-build...
[info] Resolving org.fusesource.jansi#jansi;1.4 ...
[info] Done updating.
[warn] Found version conflict(s) in library dependencies; some are suspected to be binary incompatible:
[warn]
[warn]  * commons-io:commons-io:2.4 is selected over 1.3.1
[warn]      +- com.sksamuel.scrimage:scrimage-core_2.10:2.1.7     (depends on 2.4)
[warn]      +- org.apache.xmlgraphics:xmlgraphics-commons:2.1     (depends on 1.3.1)
[warn]      +- org.apache.xmlgraphics:fop:2.1                     (depends on 1.3.1)
[warn]
[warn]  * xml-apis:xml-apis:1.3.04 is selected over 2.0.2
[warn]      +- org.apache.xmlgraphics:batik-script:1.8            (depends on 1.3.04)
[warn]      +- org.apache.xmlgraphics:batik-anim:1.8              (depends on 1.3.04)
[warn]      +- org.apache.xmlgraphics:batik-transcoder:1.8        (depends on 1.3.04)
[warn]      +- org.apache.xmlgraphics:batik-bridge:1.8            (depends on 1.3.04)
[warn]      +- org.apache.xmlgraphics:batik-svg-dom:1.8           (depends on 1.3.04)
[warn]      +- org.apache.xmlgraphics:batik-parser:1.8            (depends on 1.3.04)
[warn]      +- org.apache.xmlgraphics:batik-dom:1.8               (depends on 1.3.04)
[warn]      +- org.apache.xmlgraphics:batik-css:1.8               (depends on 1.3.04)
[warn]      +- org.apache.xmlgraphics:batik-ext:1.8               (depends on 1.3.04)
[warn]      +- org.apache.xmlgraphics:batik-extension:1.8         (depends on 1.3.04)
[warn]      +- org.apache.xmlgraphics:batik-svggen:1.8            (depends on 1.3.04)
[warn]      +- xalan:xalan:2.7.0                                  (depends on 2.0.2)
[warn]
[warn] Run 'evicted' to see detailed eviction warnings
/Users/hcastro/Projects/vectorpipe/ensime.sbt:1: error: not found: value ensimeIgnoreMissingDirectories
ensimeIgnoreMissingDirectories in ThisBuild := true
^
[error] Type error in expression
```

On the branch associated with this PR (`hmc/fix-publish-local`):

```
$ sbt publish-local
[info] Loading global plugins from /Users/hcastro/.sbt/0.13/plugins
[info] Loading project definition from /Users/hcastro/Projects/vectorpipe/project
[info] Updating {file:/Users/hcastro/Projects/vectorpipe/project/}vectorpipe-build...
[info] Resolving org.fusesource.jansi#jansi;1.4 ...
[info] Done updating.
[warn] Found version conflict(s) in library dependencies; some are suspected to be binary incompatible:
[warn]
[warn]  * commons-io:commons-io:2.4 is selected over 1.3.1
[warn]      +- com.sksamuel.scrimage:scrimage-core_2.10:2.1.7     (depends on 2.4)
[warn]      +- org.apache.xmlgraphics:xmlgraphics-commons:2.1     (depends on 1.3.1)
[warn]      +- org.apache.xmlgraphics:fop:2.1                     (depends on 1.3.1)
[warn]
[warn]  * xml-apis:xml-apis:1.3.04 is selected over 2.0.2
[warn]      +- org.apache.xmlgraphics:batik-script:1.8            (depends on 1.3.04)
[warn]      +- org.apache.xmlgraphics:batik-anim:1.8              (depends on 1.3.04)
[warn]      +- org.apache.xmlgraphics:batik-transcoder:1.8        (depends on 1.3.04)
[warn]      +- org.apache.xmlgraphics:batik-bridge:1.8            (depends on 1.3.04)
[warn]      +- org.apache.xmlgraphics:batik-svg-dom:1.8           (depends on 1.3.04)
[warn]      +- org.apache.xmlgraphics:batik-parser:1.8            (depends on 1.3.04)
[warn]      +- org.apache.xmlgraphics:batik-dom:1.8               (depends on 1.3.04)
[warn]      +- org.apache.xmlgraphics:batik-css:1.8               (depends on 1.3.04)
[warn]      +- org.apache.xmlgraphics:batik-ext:1.8               (depends on 1.3.04)
[warn]      +- org.apache.xmlgraphics:batik-extension:1.8         (depends on 1.3.04)
[warn]      +- org.apache.xmlgraphics:batik-svggen:1.8            (depends on 1.3.04)
[warn]      +- xalan:xalan:2.7.0                                  (depends on 2.0.2)
[warn]
[warn] Run 'evicted' to see detailed eviction warnings
[info] Set current project to vectorpipe (in build file:/Users/hcastro/Projects/vectorpipe/)
[info] Wrote /Users/hcastro/Projects/vectorpipe/target/scala-2.11/vectorpipe_2.11-1.0.0-SNAPSHOT.pom
[info] :: delivering :: com.azavea#vectorpipe_2.11;1.0.0-SNAPSHOT :: 1.0.0-SNAPSHOT :: integration :: Sun Oct 22 18:45:52 EDT 2017
[info]  delivering ivy file to /Users/hcastro/Projects/vectorpipe/target/scala-2.11/ivy-1.0.0-SNAPSHOT.xml
[info]  published vectorpipe_2.11 to /Users/hcastro/.ivy2/local/com.azavea/vectorpipe_2.11/1.0.0-SNAPSHOT/poms/vectorpipe_2.11.pom
[info]  published vectorpipe_2.11 to /Users/hcastro/.ivy2/local/com.azavea/vectorpipe_2.11/1.0.0-SNAPSHOT/jars/vectorpipe_2.11.jar
[info]  published vectorpipe_2.11 to /Users/hcastro/.ivy2/local/com.azavea/vectorpipe_2.11/1.0.0-SNAPSHOT/srcs/vectorpipe_2.11-sources.jar
[info]  published vectorpipe_2.11 to /Users/hcastro/.ivy2/local/com.azavea/vectorpipe_2.11/1.0.0-SNAPSHOT/docs/vectorpipe_2.11-javadoc.jar
[info]  published ivy to /Users/hcastro/.ivy2/local/com.azavea/vectorpipe_2.11/1.0.0-SNAPSHOT/ivys/ivy.xml
[success] Total time: 1 s, completed Oct 22, 2017 6:45:52 PM
```