### PR TITLE
Rework Clipping

### DIFF
--- a/src/main/scala/vectorpipe/Clip.scala
+++ b/src/main/scala/vectorpipe/Clip.scala
@@ -3,6 +3,7 @@ package vectorpipe
 import scala.collection.mutable.ListBuffer
 import scala.util.{Try, Success, Failure}
 
+import com.vividsolutions.jts.geom.prep.PreparedGeometryFactory
 import geotrellis.proj4.{LatLng, WebMercator}
 import geotrellis.vector._
 import geotrellis.vector.io._
@@ -74,15 +75,35 @@ object Clip {
     centre.distanceToSegment(p1, p2) <= radius
 
   /** Naively clips Features to fit the given Extent. */
-  def byExtent[G <: Geometry, D](extent: Extent, f: Feature[G, D]): Option[Feature[Geometry, D]] = {
-    val exPoly: Polygon = extent.toPolygon
+  def byExtent[G <: Geometry, D](extent: Extent, f: Feature[G, D]): Option[Feature[Geometry, D]] = f.geom match {
+    case g: Point                              => Some(f)
+    case g: MultiPoint if coveredBy(g, extent) => Some(f)
+    case g: MultiPoint                         => clip(extent, g).map(Feature(_, f.data))
+    case g: Line       if coveredBy(g, extent) => Some(f)
+    case g: Line                               => clip(extent, g).map(Feature(_, f.data))
+    case g: MultiLine  if coveredBy(g, extent) => Some(f)
+    case g: MultiLine                          => clip(extent, g).map(Feature(_, f.data))
+    case g =>  /* Polygon and MultiPolygon */
+      val pg = PreparedGeometryFactory.prepare(g.jtsGeom)
+      val ep = extent.toPolygon.jtsGeom
 
-    val clipped: Try[Geometry] = f.geom match {
+      if (pg.covers(ep)) Some(Feature(extent, f.data))
+      else if (pg.coveredBy(ep)) Some(f)
+      else clip(extent, g).map(Feature(_, f.data))
+  }
+
+  private def coveredBy[G <: Geometry](g: G, e: Extent): Boolean =
+    g.jtsGeom.coveredBy(e.toPolygon.jtsGeom)
+
+  private def clip[G <: Geometry](e: Extent, g: G): Option[Geometry] = {
+    val exPoly: Polygon = e.toPolygon
+
+    val clipped: Try[Geometry] = g match {
       case mp: MultiPolygon => Try(MultiPolygon(mp.polygons.flatMap(_.intersection(exPoly).as[Polygon])))
-      case _ => Try(f.geom.intersection(exPoly).toGeometry.get)
+      case _ => Try(g.intersection(exPoly).toGeometry.get)
     }
 
-    clipped.toOption.map(g => Feature(g, f.data))
+    clipped.toOption
   }
 
   /** Clips Features to a 3x3 grid surrounding the current Tile.
@@ -90,15 +111,12 @@ object Clip {
     * outside their original Tile, and helps avoid the pain of
     * restitching later.
     */
-  def byBufferedExtent[G <: Geometry, D](extent: Extent, f: Feature[G, D]): Option[Feature[Geometry, D]] =
-    byExtent(extent.expandBy(extent.width, extent.height), f)
-
-  /** Bias the clipping strategy based on the incoming [[Geometry]]. */
-  def byHybrid[G <: Geometry, D](extent: Extent, f: Feature[G, D]): Option[Feature[Geometry, D]] = f.geom match {
-    case pnt: Point => Some(f)  /* A `Point` will always fall within the Extent */
-    case line: Line => Some(Feature(toNearestPoint(extent, line), f.data))
-    case poly: Polygon => byBufferedExtent(extent, f)
-    case mply: MultiPolygon => byBufferedExtent(extent, f)
+  def byBufferedExtent[G <: Geometry, D](
+    extent: Extent,
+    f: Feature[G, D]
+  ): Option[Feature[Geometry, D]] = f.geom match {
+    case g: Point => Some(f)  /* A `Point` will always fall within the Extent */
+    case _ => byExtent(extent.expandBy(extent.width, extent.height), f)
   }
 
   /** Yield an [[Feature]] as-is. */

--- a/src/main/scala/vectorpipe/Clip.scala
+++ b/src/main/scala/vectorpipe/Clip.scala
@@ -18,8 +18,8 @@ object Clip {
     *
     * @see [[https://github.com/geotrellis/vectorpipe/issues/11]]
     */
-  def toNearestPoint(extent: Extent, line: Line): MultiLine = {
-    val origPoints: Array[Point] = line.points
+  def toNearestPoint[D](extent: Extent, line: Feature[Line, D]): Feature[MultiLine, D] = {
+    val origPoints: Array[Point] = line.geom.points
     val points: Array[Point] = origPoints.tail
 
     /* Setting these here makes calls to `Clip.intersects` faster */
@@ -64,7 +64,7 @@ object Clip {
       lines.append(Line(acc))
     }
 
-    MultiLine(lines)
+    Feature(MultiLine(lines), line.data)
   }
 
   /** A faster way to test Line-Extent intersection, when it's known that:

--- a/src/test/scala/vectorpipe/ClipSpec.scala
+++ b/src/test/scala/vectorpipe/ClipSpec.scala
@@ -12,28 +12,28 @@ class ClipSpec extends FunSpec with Matchers {
     it("all in") {
       val line = Line(Point(1,1), Point(2,2), Point(3,3))
 
-      Clip.toNearestPoint(extent, line) shouldBe MultiLine(line)
+      Clip.toNearestPoint(extent, Feature(line, Unit)) shouldBe Feature(MultiLine(line), Unit)
     }
 
     it("one side out") {
       val line = Line(Point(1,1), Point(2,2), Point(3,3), Point(7,7), Point(8,8), Point(9,9))
       val expected = Line(Point(1,1), Point(2,2), Point(3,3), Point(7,7))
 
-      Clip.toNearestPoint(extent, line) shouldBe MultiLine(expected)
+      Clip.toNearestPoint(extent, Feature(line, Unit)) shouldBe Feature(MultiLine(expected), Unit)
     }
 
     it("both sides out") {
       val line = Line(Point(-5,-5), Point(-1,-1), Point(1,1), Point(2,2), Point(3,3), Point(7,7), Point(8,8), Point(9,9))
       val expected = Line(Point(-1,-1), Point(1,1), Point(2,2), Point(3,3), Point(7,7))
 
-      Clip.toNearestPoint(extent, line) shouldBe MultiLine(expected)
+      Clip.toNearestPoint(extent, Feature(line, Unit)) shouldBe Feature(MultiLine(expected), Unit)
     }
 
     /* Brief exits of the Extent shouldn't result in a split */
     it("in - out - in") {
       val line = Line(Point(2,3), Point(-1,3), Point(2,2))
 
-      Clip.toNearestPoint(extent, line) shouldBe MultiLine(line)
+      Clip.toNearestPoint(extent, Feature(line, Unit)) shouldBe Feature(MultiLine(line), Unit)
     }
 
     it("loop out and back in") {
@@ -46,7 +46,7 @@ class ClipSpec extends FunSpec with Matchers {
         Line(Point(-1,4), Point(2,4), Point(4,4))
       )
 
-      Clip.toNearestPoint(extent, line) shouldBe expected
+      Clip.toNearestPoint(extent, Feature(line, Unit)) shouldBe Feature(expected, Unit)
 
     }
 
@@ -54,7 +54,7 @@ class ClipSpec extends FunSpec with Matchers {
     it("star") {
       val line = Line(Point(3,2), Point(4,7), Point(5,3), Point(9,3), Point(4,1))
 
-      Clip.toNearestPoint(extent, line) shouldBe MultiLine(line)
+      Clip.toNearestPoint(extent, Feature(line, Unit)) shouldBe Feature(MultiLine(line), Unit)
     }
 
     /* The Line has no Points in this Extent, but passes through it */
@@ -62,7 +62,7 @@ class ClipSpec extends FunSpec with Matchers {
       val line = Line(Point(-2,-2), Point(-1,-1), Point(6,6), Point(7,7))
       val expected = Line(Point(-1,-1), Point(6,6))
 
-      Clip.toNearestPoint(extent, line) shouldBe MultiLine(expected)
+      Clip.toNearestPoint(extent, Feature(line, Unit)) shouldBe Feature(MultiLine(expected), Unit)
     }
   }
 }


### PR DESCRIPTION
This is an experimental PR to explore how `ClipToGrid` from GeoTrellis can potentially be refactored. It separates the `Feature <-> SpatialKey` association with the actual clipping, a process which is more tightly coupled in the original `ClipToGrid`.