### PR TITLE
Integrate ClipToGrid

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -25,10 +25,10 @@ val common = Seq(
       exclude("javax.servlet.jsp", "jsp-api")
       exclude("org.mortbay.jetty", "servlet-api"),
     "org.apache.spark"            %% "spark-hive"            % "2.2.0" % "provided",
-    "org.locationtech.geotrellis" %% "geotrellis-spark"      % "1.2.0-RC1",
-    "org.locationtech.geotrellis" %% "geotrellis-util"       % "1.2.0-RC1",
-    "org.locationtech.geotrellis" %% "geotrellis-vector"     % "1.2.0-RC1",
-    "org.locationtech.geotrellis" %% "geotrellis-vectortile" % "1.2.0-RC1",
+    "org.locationtech.geotrellis" %% "geotrellis-spark"      % "1.2.0-SNAPSHOT",
+    "org.locationtech.geotrellis" %% "geotrellis-util"       % "1.2.0-SNAPSHOT",
+    "org.locationtech.geotrellis" %% "geotrellis-vector"     % "1.2.0-SNAPSHOT",
+    "org.locationtech.geotrellis" %% "geotrellis-vectortile" % "1.2.0-SNAPSHOT",
     "org.scalatest"               %% "scalatest"             % "3.0.1" % "test",
     "org.spire-math"              %% "spire"                 % "0.13.0",
     "org.typelevel"               %% "cats-core"             % "1.0.0-MF"

--- a/src/main/scala/vectorpipe/Clip.scala
+++ b/src/main/scala/vectorpipe/Clip.scala
@@ -1,9 +1,7 @@
 package vectorpipe
 
 import scala.annotation.tailrec
-import scala.util.Try
 
-import geotrellis.proj4.{LatLng, WebMercator}
 import geotrellis.spark.clip.ClipToGrid
 import geotrellis.spark.clip.ClipToGrid.Predicates
 import geotrellis.vector._

--- a/src/main/scala/vectorpipe/Clip.scala
+++ b/src/main/scala/vectorpipe/Clip.scala
@@ -4,6 +4,8 @@ import scala.annotation.tailrec
 import scala.util.Try
 
 import geotrellis.proj4.{LatLng, WebMercator}
+import geotrellis.spark.clip.ClipToGrid
+import geotrellis.spark.clip.ClipToGrid.Predicates
 import geotrellis.vector._
 
 // --- //
@@ -54,34 +56,26 @@ object Clip {
     centre.distanceToSegment(p1, p2) <= radius
 
   /** Naively clips Features to fit the given Extent. */
-  def byExtent[G <: Geometry, D](extent: Extent, f: Feature[G, D]): Option[Feature[Geometry, D]] = {
-    val exPoly: Polygon = extent.toPolygon
-
-    val clipped: Try[Geometry] = f.geom match {
-      case mp: MultiPolygon => Try(MultiPolygon(mp.polygons.flatMap(_.intersection(exPoly).as[Polygon])))
-      case _ => Try(f.geom.intersection(exPoly).toGeometry.get)
-    }
-
-    clipped.toOption.map(g => Feature(g, f.data))
-  }
+  def byExtent[G <: Geometry, D](extent: Extent, f: Feature[G, D], p: Predicates): Option[Feature[Geometry, D]] =
+    ClipToGrid.clipFeatureToExtent(extent, f, p)
 
   /** Clips Features to a 3x3 grid surrounding the current Tile.
     * This has been found to capture ''most'' Features which stretch
     * outside their original Tile, and helps avoid the pain of
     * restitching later.
     */
-  def byBufferedExtent[G <: Geometry, D](extent: Extent, f: Feature[G, D]): Option[Feature[Geometry, D]] =
-    byExtent(extent.expandBy(extent.width, extent.height), f)
+  def byBufferedExtent[G <: Geometry, D](extent: Extent, f: Feature[G, D], p: Predicates): Option[Feature[Geometry, D]] =
+    byExtent(extent.expandBy(extent.width, extent.height), f, p)
 
   /** Bias the clipping strategy based on the incoming [[Geometry]]. */
-  def byHybrid[G <: Geometry, D](extent: Extent, f: Feature[G, D]): Option[Feature[Geometry, D]] = f.geom match {
-    case pnt: Point => Some(f)  /* A `Point` will always fall within the Extent */
-    case line: Line => Some(Feature(toNearestPoint(extent, line), f.data))
-    case poly: Polygon => byBufferedExtent(extent, f)
-    case mply: MultiPolygon => byBufferedExtent(extent, f)
-    case _ => None
+  def byHybrid[G <: Geometry, D](extent: Extent, f: Feature[G, D], p: Predicates): Option[Feature[Geometry, D]] = f.geom match {
+    case pnt: Point         => Some(f)  /* A `Point` will always fall within the Extent */
+    case line: Line         => Some(Feature(toNearestPoint(extent, line), f.data))
+    case poly: Polygon      => byBufferedExtent(extent, f, p)
+    case mply: MultiPolygon => byBufferedExtent(extent, f, p)
+    case _                  => None
   }
 
   /** Yield an [[Feature]] as-is. */
-  def asIs[G <: Geometry, D](extent: Extent, f: Feature[G, D]): Option[Feature[G, D]] = Some(f)
+  def asIs[G <: Geometry, D](extent: Extent, f: Feature[G, D], p: Predicates): Option[Feature[G, D]] = Some(f)
 }

--- a/src/main/scala/vectorpipe/VectorPipe.scala
+++ b/src/main/scala/vectorpipe/VectorPipe.scala
@@ -3,7 +3,6 @@ package vectorpipe
 import geotrellis.proj4._
 import geotrellis.raster.GridBounds
 import geotrellis.spark._
-import geotrellis.spark.clip.ClipToGrid
 import geotrellis.spark.clip.ClipToGrid.Predicates
 import geotrellis.spark.tiling._
 import geotrellis.vector._
@@ -136,7 +135,7 @@ object VectorPipe {
       }
     }
 
-    ClipToGrid(rdd, ld, work _).groupByKey
+    rdd.clipToGrid(ld, work _).groupByKey
   }
 
   /* Takes advantage of the fact that most Geoms are small, and only occur in one Tile */

--- a/src/main/scala/vectorpipe/VectorPipe.scala
+++ b/src/main/scala/vectorpipe/VectorPipe.scala
@@ -3,12 +3,16 @@ package vectorpipe
 import geotrellis.proj4._
 import geotrellis.raster.GridBounds
 import geotrellis.spark._
+import geotrellis.spark.clip.ClipToGrid
+import geotrellis.spark.clip.ClipToGrid.Predicates
 import geotrellis.spark.tiling._
 import geotrellis.vector._
 import geotrellis.vector.io._
 import geotrellis.vectortile.VectorTile
 import org.apache.log4j.Logger
 import org.apache.spark.rdd._
+
+import scala.util.{ Try, Success, Failure }
 
 // --- //
 
@@ -114,45 +118,25 @@ object VectorPipe {
     * @param logError An IO function that will log any clipping failures.
     */
   def toGrid[G <: Geometry, D](
-    clip: (Extent, Feature[G, D]) => Option[Feature[G, D]],
+    clip: (Extent, Feature[G, D], Predicates) => Option[Feature[Geometry, D]],
     logError: (((Extent, Feature[G, D])) => String) => ((Extent, Feature[G, D])) => Unit,
     ld: LayoutDefinition,
     rdd: RDD[Feature[G, D]]
-  ): RDD[(SpatialKey, Iterable[Feature[G, D]])] = {
-
-    val mt: MapKeyTransform = ld.mapTransform
-
-    /* Initial bounding box for capturing Features */
-    val extent: Polygon = ld.extent.toPolygon
-
-    /* Filter once to reduce later workload */
-    // TODO: This may be an unnecessary bottleneck.
-    // val bounded: RDD[Feature[G, D]] = rdd.filter(f => f.geom.intersects(extent))
-
-    /* Associate each Feature with a SpatialKey */
-    val grid: RDD[(SpatialKey, Feature[G, D])] = rdd.flatMap(f => byIntersect(mt, f))
+  ): RDD[(SpatialKey, Iterable[Feature[Geometry, D]])] = {
 
     /** A way to render some Geometry that failed to clip. */
     val errorClipping: ((Extent, Feature[G, D])) => String = { case (e, f) =>
       s"CLIP FAILURE W/ EXTENT: ${e}\nELEMENT METADATA: ${f.data}\nGEOM: ${f.geom.reproject(WebMercator, LatLng).toGeoJson}"
     }
 
-    grid.groupByKey().map { case (k, iter) =>
-      val kExt: Extent = mt(k)
-
-      /* Clip each geometry in some way */
-      val clipped: List[Feature[G, D]] = iter.foldLeft(List.empty[Feature[G, D]]) { (acc, g) =>
-        clip(kExt, g) match {
-          case Some(h) => h :: acc
-          case None => {
-            logError(errorClipping)((kExt, g)) /* Sneaky IO to log the error */
-            acc
-          }
-        }
+    def work(e: Extent, f: Feature[G, D], p: Predicates): Option[Feature[Geometry, D]] = {
+      Try(clip(e, f, p)) match {
+        case Failure(_) => logError(errorClipping)((e, f)); None
+        case Success(g) => g
       }
-
-      (k, clipped)
     }
+
+    ClipToGrid(rdd, ld, work _).groupByKey
   }
 
   /* Takes advantage of the fact that most Geoms are small, and only occur in one Tile */


### PR DESCRIPTION
### TODO

- [x] `VectorPipe.toGrid` calls `ClipToGrid`
- [x] Rework VP's clipping functions

### Motivation

The `RDD[Geometry] => RDD[(SpatialKey, Geometry)]` logic was ported back to GeoTrellis, so now we need to use it.