### PR TITLE
Mark hadoop-aws as provided

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -20,10 +20,7 @@ val common = Seq(
 
   libraryDependencies ++= Seq(
     "io.dylemma"                  %% "xml-spac"              % "0.3",
-    "org.apache.hadoop"           %  "hadoop-aws"            % "2.8.1"
-      exclude("javax.servlet",     "servlet-api")
-      exclude("javax.servlet.jsp", "jsp-api")
-      exclude("org.mortbay.jetty", "servlet-api"),
+    "org.apache.hadoop"           %  "hadoop-aws"            % "2.8.1" % "provided",
     "org.apache.spark"            %% "spark-hive"            % "2.2.0" % "provided",
     "org.locationtech.geotrellis" %% "geotrellis-spark"      % "1.2.0-SNAPSHOT",
     "org.locationtech.geotrellis" %% "geotrellis-util"       % "1.2.0-SNAPSHOT",


### PR DESCRIPTION
This change will allow our jar to be included in EMR without trouble. This PR doesn't address the `useS3` function which will work for apache's `hadoop-aws` but not for Amazon's proprietary fork of `hadoop-aws`.