### PR TITLE
Fix line order bug

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -15,10 +15,16 @@ val common = Seq(
   ),
 
   scalacOptions := Seq(
+    "-deprecation",
     "-Ypartial-unification"
   ),
 
+  /* For Monocle's Lens auto-generation */
+  addCompilerPlugin("org.scalamacros" %% "paradise" % "2.1.0" cross CrossVersion.full),
+
   libraryDependencies ++= Seq(
+    "com.github.julien-truffaut"  %% "monocle-core"          % "1.5.0-cats-M2",
+    "com.github.julien-truffaut"  %% "monocle-macro"         % "1.5.0-cats-M2",
     "io.dylemma"                  %% "xml-spac"              % "0.3",
     "org.apache.hadoop"           %  "hadoop-aws"            % "2.8.1" % "provided",
     "org.apache.spark"            %% "spark-hive"            % "2.2.0" % "provided",

--- a/src/main/scala/vectorpipe/osm/Element.scala
+++ b/src/main/scala/vectorpipe/osm/Element.scala
@@ -99,7 +99,7 @@ case class Way(
   /** Is it a Polyline, but not an "Area" even if closed? */
   def isLine: Boolean = !isClosed || (!isArea && isHighwayOrBarrier)
 
-  def isClosed: Boolean = if (nodes.isEmpty) false else nodes(0) === nodes.last
+  def isClosed: Boolean = (nodes.headOption, nodes.lastOption).mapN(_ === _).getOrElse(false)
 
   def isArea: Boolean = data.tagMap.get("area").map(_ === "yes").getOrElse(false)
 

--- a/src/main/scala/vectorpipe/osm/Element.scala
+++ b/src/main/scala/vectorpipe/osm/Element.scala
@@ -5,6 +5,7 @@ import java.time._
 import cats.implicits._
 import geotrellis.vector.{ Extent, Point }
 import io.dylemma.spac._
+import monocle.macros.Lenses
 
 // --- //
 
@@ -21,7 +22,7 @@ private[vectorpipe] object Element {
     Parser.forMandatoryAttribute("changeset").map(_.toLong) ~
     Parser.forMandatoryAttribute("version").map(_.toLong) ~
     Parser.forMandatoryAttribute("timestamp").map(Instant.parse(_)) ~
-    Parser.forOptionalAttribute("visible").map(_.map(_.toBoolean).getOrElse(false))).as(ElementMeta)
+    Parser.forOptionalAttribute("visible").map(_.map(_.toBoolean).getOrElse(false))).as(ElementMeta.apply)
 
   /* <tag k='access' v='permissive' /> */
   implicit val tag: Parser[(String, String)] = (
@@ -123,10 +124,11 @@ case class Member(
   ref: Long,
   role: String)
 
-case class ElementData(meta: ElementMeta, tagMap: Map[String, String])
+/** All Elements have common attributes, and may also have additional "tags". */
+@Lenses case class ElementData(meta: ElementMeta, tagMap: Map[String, String])
 
 /** All Element types have these attributes in common. */
-case class ElementMeta(
+@Lenses case class ElementMeta(
   id: Long,
   user: String,
   userId: Long,

--- a/src/main/scala/vectorpipe/osm/internal/ElementToFeature.scala
+++ b/src/main/scala/vectorpipe/osm/internal/ElementToFeature.scala
@@ -283,7 +283,7 @@ private[vectorpipe] object ElementToFeature {
     case Vector()  => Vector.empty.pure[LineState]
     case Vector(h) => State.modify[List[OSMLine]](h :: _).map(_ => Vector.empty)
     case v => fuseOne(v) match {
-      case None => State.modify[List[OSMLine]](v.head :: _) >> fuseLines(v.tail)
+      case None => State.modify[List[OSMLine]](v.head :: _) *> fuseLines(v.tail)
       case Some((f, d, i, rest)) => {
         if (f.isClosed)
           fuseLines(rest).map(c => Feature(Polygon(f), d) +: c)

--- a/src/main/scala/vectorpipe/osm/internal/PlanetHistory.scala
+++ b/src/main/scala/vectorpipe/osm/internal/PlanetHistory.scala
@@ -53,6 +53,9 @@ private[vectorpipe] object PlanetHistory {
       ps: List[OSMPolygon]
     ): (List[OSMLine], List[OSMPolygon]) = ws match {
       case Nil => (ls, ps)
+      /* OSM Extracts can produce degenerate Ways. These two checks guard against those. */
+      case w :: _ if w.nodes.length < 4 && w.isClosed => (ls, ps)
+      case w :: _ if w.nodes.length < 2 => (ls, ps)
       case w :: rest => {
 
         /* Y2K bug here, except it won't manifest until the end of the year 1 billion AD */

--- a/src/main/scala/vectorpipe/osm/internal/PlanetHistory.scala
+++ b/src/main/scala/vectorpipe/osm/internal/PlanetHistory.scala
@@ -108,9 +108,7 @@ private[vectorpipe] object PlanetHistory {
 
       points.map { ps =>
         // TODO Overwrite more values?
-        // TODO Lenses!
-        val feature = Feature(f(ps), w.data.copy(meta = w.data.meta.copy(timestamp = i)))
-        feature :: acc
+        Feature(f(ps), (ElementData.meta ^|-> ElementMeta.timestamp).set(i)(w.data)) :: acc
       }.getOrElse(acc)
     }
   }

--- a/src/main/scala/vectorpipe/osm/internal/PlanetHistory.scala
+++ b/src/main/scala/vectorpipe/osm/internal/PlanetHistory.scala
@@ -4,6 +4,7 @@ import java.time.Instant
 
 import scala.annotation.tailrec
 
+import cats.implicits._
 import geotrellis.vector._
 import org.apache.spark.rdd.RDD
 import vectorpipe.osm._
@@ -76,21 +77,11 @@ private[vectorpipe] object PlanetHistory {
             }
 
         if (w.isClosed) {
-          val everyPoly: List[OSMPolygon] = allSlices.map { case (i, ns) =>
-            Feature(
-              Polygon(Line(ns.values.map(n => Point(n.lon, n.lat)))),
-              w.data.copy(meta = w.data.meta.copy(timestamp = i)) // TODO Overwrite more values?
-            )
-          }
+          val everyPoly: List[OSMPolygon] = feature({ ps => Polygon(Line(ps)) }, w, allSlices)
 
           work(rest, ls, ps ++ everyPoly)
         } else {
-          val everyLine: List[OSMLine] = allSlices.map { case (i, ns) =>
-            Feature(
-              Line(ns.values.map(n => Point(n.lon, n.lat))),
-              w.data.copy(meta = w.data.meta.copy(timestamp = i)) // TODO Overwrite more values?
-            )
-          }
+          val everyLine: List[OSMLine] = feature({ ps => Line(ps) }, w, allSlices)
 
           work(rest, ls ++ everyLine, ps)
         }
@@ -100,6 +91,28 @@ private[vectorpipe] object PlanetHistory {
 
     /* Ensure the Ways are sorted before proceeding */
     work(ways.sortBy(_.data.meta.timestamp), Nil, Nil)
+  }
+
+  /** Construct GeoTrellis Features from the given time slices. */
+  private[this] def feature[G <: Geometry](
+    f: Vector[Point] => G,
+    w: Way,
+    slices: List[(Instant, Map[Long, Node])]
+  ): List[Feature[G, ElementData]] = {
+    slices.foldLeft(Nil: List[Feature[G, ElementData]]) { case (acc, (i, ns)) =>
+      /* If a Node were deleted that the Way still expected, then no Line
+       * should be formed.
+       */
+      val points: Option[Vector[Point]] =
+        w.nodes.map(id => ns.get(id).map(n => Point(n.lon, n.lat))).sequence
+
+      points.map { ps =>
+        // TODO Overwrite more values?
+        // TODO Lenses!
+        val feature = Feature(f(ps), w.data.copy(meta = w.data.meta.copy(timestamp = i)))
+        feature :: acc
+      }.getOrElse(acc)
+    }
   }
 
   /** Given a collection of all Nodes ever associated with a [[Way]], which subset


### PR DESCRIPTION
Previously I wasn't respecting the original Node order when construction `Line`s. This resulted in some exception throwing in OSMesa.