### PR TITLE
Yield all (simple) Historical Features

### DIFF
--- a/src/main/scala/vectorpipe/osm/internal/PlanetHistory.scala
+++ b/src/main/scala/vectorpipe/osm/internal/PlanetHistory.scala
@@ -53,10 +53,9 @@ private[vectorpipe] object PlanetHistory {
     val nodesToWayIds: RDD[(Node, Iterable[Long])] =
       nodes
         .cogroup(nodeIdsToWayIds)
-        .flatMap {
-          /* The `.distinct` above ensures that `wayIds` here will contain unique values. */
-          case (_, (ns, wayIds)) => ns.map(n => (n, wayIds))
-        }
+        /* The `.distinct` above ensures that `wayIds` here will contain unique values. */
+        .flatMap { case (_, (ns, wayIds)) => ns.map(n => (n, wayIds)) }
+        .cache
 
     /* Not /that/ much duplication, as most Nodes are only needed by one Way (if any).
      * Any standalone Node whose `wayIds` is empty will be crushed away by the flatMap,

--- a/src/main/scala/vectorpipe/osm/package.scala
+++ b/src/main/scala/vectorpipe/osm/package.scala
@@ -269,6 +269,6 @@ package object osm {
   def toHistory(
     nodes: RDD[(Long, Node)],
     ways: RDD[(Long, Way)]
-  ): (RDD[Feature[Line, ElementMeta]], RDD[Feature[Polygon, ElementMeta]]) =
+  ): (RDD[Feature[Point, ElementMeta]], RDD[Feature[Line, ElementMeta]], RDD[Feature[Polygon, ElementMeta]]) =
     PlanetHistory.features(nodes, ways)
 }

--- a/src/main/scala/vectorpipe/osm/package.scala
+++ b/src/main/scala/vectorpipe/osm/package.scala
@@ -214,7 +214,7 @@ package object osm {
    *     across its child members. Otherwise, Relations are "dropped"
    *     from the output.
    */
-  def toFeatures(
+  def toSnapshot(
     logError: (Feature[Line, ElementMeta] => String) => Feature[Line, ElementMeta] => Unit,
     nodes: RDD[Node],
     ways: RDD[Way],
@@ -255,7 +255,20 @@ package object osm {
     nodes.sparkContext.union(pnt, lns, pls, mps)
   }
 
-  /** All Lines that could be reconstructed from OSM Elements. */
-  def toLines(nodes: RDD[(Long, Node)], ways: RDD[(Long, Way)]): RDD[Feature[Line, ElementMeta]] =
-    PlanetHistory.lines(nodes, ways)
+  @deprecated("Use toSnapshot instead.", "2017-11-14")
+  def toFeatures(
+    logError: (Feature[Line, ElementMeta] => String) => Feature[Line, ElementMeta] => Unit,
+    nodes: RDD[Node],
+    ways: RDD[Way],
+    relations: RDD[Relation]
+  ): RDD[OSMFeature] = toSnapshot(logError, nodes, ways, relations)
+
+  /** All Lines and Polygons that could be reconstructed from a set of all
+    * historical OSM Elements.
+    */
+  def toHistory(
+    nodes: RDD[(Long, Node)],
+    ways: RDD[(Long, Way)]
+  ): (RDD[Feature[Line, ElementMeta]], RDD[Feature[Polygon, ElementMeta]]) =
+    PlanetHistory.features(nodes, ways)
 }


### PR DESCRIPTION
### TODO

- [x] Return constructed Polygons
- [x] Return standalone Nodes as GeoTrellis Points
- [x] Fixed bug which caused most historical nodes to be dropped
- [x] Microsite still builds

**Note:** This doesn't yet include complex Polygons formed from relations - only simple ones from Ways. These are the vast majority.