### PR TITLE
(history) Filter degenerate Polygons

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,11 @@ val common = Seq(
 
   scalacOptions := Seq(
     "-deprecation",
-    "-Ypartial-unification"
+    "-Ypartial-unification",
+    "-Ywarn-value-discard",
+    "-Ywarn-unused-import",
+    "-Ywarn-dead-code",
+    "-Ywarn-numeric-widen"
   ),
 
   /* For Monocle's Lens auto-generation */

--- a/src/main/scala/vectorpipe/VectorPipe.scala
+++ b/src/main/scala/vectorpipe/VectorPipe.scala
@@ -1,7 +1,6 @@
 package vectorpipe
 
 import geotrellis.proj4._
-import geotrellis.raster.GridBounds
 import geotrellis.spark._
 import geotrellis.spark.clip.ClipToGrid.Predicates
 import geotrellis.spark.tiling._
@@ -161,6 +160,6 @@ object VectorPipe {
   def logToLog4j[A](f: A => String): A => Unit = { a => Logger.getRootLogger().error(f(a)) }
 
   /** Skip over some failure. */
-  def logNothing[A](f: A => String): A => Unit = { _ => Unit }
+  def logNothing[A](f: A => String): A => Unit = { _ => () }
 
 }

--- a/src/main/scala/vectorpipe/osm/Element.scala
+++ b/src/main/scala/vectorpipe/osm/Element.scala
@@ -3,7 +3,6 @@ package vectorpipe.osm
 import java.time._
 
 import cats.implicits._
-import geotrellis.vector.{ Extent, Point }
 import io.dylemma.spac._
 import monocle.macros.Lenses
 

--- a/src/main/scala/vectorpipe/osm/internal/ElementToFeature.scala
+++ b/src/main/scala/vectorpipe/osm/internal/ElementToFeature.scala
@@ -1,7 +1,5 @@
 package vectorpipe.osm.internal
 
-import scala.collection.parallel.ParSeq
-
 import cats.data.State
 import cats.implicits._
 import com.vividsolutions.jts.geom.LineString
@@ -11,9 +9,7 @@ import geotrellis.util._
 import geotrellis.vector._
 import geotrellis.vector.io._
 import org.apache.spark.rdd._
-import spire.std.any._
 import vectorpipe.osm._
-import vectorpipe.util._
 
 // --- //
 

--- a/src/main/scala/vectorpipe/osm/package.scala
+++ b/src/main/scala/vectorpipe/osm/package.scala
@@ -5,10 +5,7 @@ import java.io.{ FileInputStream, InputStream }
 import scala.util.{ Failure, Success, Try }
 
 import cats.implicits._
-import geotrellis.proj4._
 import geotrellis.vector._
-import geotrellis.vector.io._
-import org.apache.log4j.Logger
 import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql._

--- a/src/main/scala/vectorpipe/osm/package.scala
+++ b/src/main/scala/vectorpipe/osm/package.scala
@@ -269,6 +269,19 @@ package object osm {
   def toHistory(
     nodes: RDD[(Long, Node)],
     ways: RDD[(Long, Way)]
-  ): (RDD[Feature[Point, ElementMeta]], RDD[Feature[Line, ElementMeta]], RDD[Feature[Polygon, ElementMeta]]) =
-    PlanetHistory.features(nodes, ways)
+  ): (RDD[Feature[Point, ElementMeta]], RDD[Feature[Line, ElementMeta]], RDD[Feature[Polygon, ElementMeta]]) = {
+    val (points, lines, polygons) = PlanetHistory.features(nodes, ways)
+
+    /* Depending on the dataset used, `Way` data may be incomplete. That is,
+     * the local version of a Way may have fewer Node references that the original
+     * as found on OpenStreetMap. These usually occur along "dataset bounding
+     * boxes" found in OSM subregion extracts, where a Polygon is cut in half by
+     * the BBOX. The resulting Polygons, with only a subset of the original Nodes,
+     * are often self-intersecting. This causes Topology Exceptions during the
+     * clipping stage of the pipeline. Our only recourse is to remove them here.
+     *
+     * See: https://github.com/geotrellis/vectorpipe/pull/16#issuecomment-290144694
+     */
+    (points, lines, polygons.filter(_.geom.isValid))
+  }
 }

--- a/src/test/scala/vectorpipe/osm/FeatureConstruction.scala
+++ b/src/test/scala/vectorpipe/osm/FeatureConstruction.scala
@@ -34,7 +34,7 @@ class FeatureConstruction extends FunSpec with Matchers {
   ).map { case (id, v, time) =>
       val (lat, lon) = locations(id.toLong)
 
-      Node(lat, lon, ElementMeta(id, "colin", 123, 1, v, Instant.ofEpochMilli(time), true, Map.empty))
+      Node(lat, lon, ElementMeta(id.toLong, "colin", 123, 1, v.toLong, Instant.ofEpochMilli(time.toLong), true, Map.empty))
   }
 
   describe("linesAndPolys") {


### PR DESCRIPTION
We had always done something like this on the Snapshot side, but we forgot to bring this detail over to the History code. If we don't include this logic, VectorPipe runs over country extracts will almost certainly run into degenerate Ways, which don't play well with later steps.