### PR TITLE
Minor versions

### DIFF
--- a/src/main/scala/vectorpipe/osm/Element.scala
+++ b/src/main/scala/vectorpipe/osm/Element.scala
@@ -140,5 +140,5 @@ object ElementMeta {
     timestamp: Instant,
     visible: Boolean,
     tags: Map[String, String]
-  ) = new ElementMeta(id, user, uid, changeset, version, 0, timestamp, visible, tags)
+  ) : ElementMeta = new ElementMeta(id, user, uid, changeset, version, 0, timestamp, visible, tags)
 }

--- a/src/main/scala/vectorpipe/osm/Element.scala
+++ b/src/main/scala/vectorpipe/osm/Element.scala
@@ -124,7 +124,21 @@ private[vectorpipe] object Element {
   uid: Long,
   changeset: Long,
   version: Long,
+  minorVersion: Long,
   timestamp: Instant,
   visible: Boolean,
   tags: Map[String, String]
 )
+
+object ElementMeta {
+  def apply(
+    id: Long,
+    user: String,
+    uid: Long,
+    changeset: Long,
+    version: Long,
+    timestamp: Instant,
+    visible: Boolean,
+    tags: Map[String, String]
+  ) = new ElementMeta(id, user, uid, changeset, version, 0, timestamp, visible, tags)
+}

--- a/src/main/scala/vectorpipe/osm/internal/PlanetHistory.scala
+++ b/src/main/scala/vectorpipe/osm/internal/PlanetHistory.scala
@@ -119,7 +119,8 @@ private[vectorpipe] object PlanetHistory {
                   user      = meta.user,
                   uid       = meta.uid,
                   changeset = meta.changeset,
-                  timestamp = meta.timestamp
+                  timestamp = meta.timestamp,
+                  minorVersion = prevMeta.minorVersion + 1
                 )
               } else {
                 prevMeta


### PR DESCRIPTION
This assigns a `minorVersion` to each feature.

This is useful for a) distinguishing between edits of the element itself and those referred to and b) providing an additional component to use as a key when referring to specific geometry versions.

(This incorporates #41)