### PR TITLE
Separated Feature RDDs

### DIFF
--- a/src/main/scala/vectorpipe/osm/Features.scala
+++ b/src/main/scala/vectorpipe/osm/Features.scala
@@ -16,7 +16,7 @@ case class Features(
   multiPolys: RDD[Feature[MultiPolygon, ElementMeta]]
 ) {
   /** Flatten the separated features into a single `RDD` of their supertype, `Geometry`. */
-  def geometries: RDD[Feature[Geometry, ElementMeta]] = points.sparkContext.union(
+  def geometries: RDD[OSMFeature] = points.sparkContext.union(
     points.map(identity), lines.map(identity), polygons.map(identity), multiPolys.map(identity)
   )
 }

--- a/src/main/scala/vectorpipe/osm/Features.scala
+++ b/src/main/scala/vectorpipe/osm/Features.scala
@@ -1,0 +1,22 @@
+package vectorpipe.osm
+
+import geotrellis.vector._
+import org.apache.spark.rdd.RDD
+
+// --- //
+
+/** A meaningful wrapping around the various geometry types that can be produced
+  * from the OSM-to-Features conversion. By keeping each Geometry subtype separate,
+  * the user can discard types they don't need.
+  */
+case class Features(
+  points:     RDD[Feature[Point, ElementMeta]],
+  lines:      RDD[Feature[Line, ElementMeta]],
+  polygons:   RDD[Feature[Polygon, ElementMeta]],
+  multiPolys: RDD[Feature[MultiPolygon, ElementMeta]]
+) {
+  /** Flatten the separated features into a single `RDD` of their supertype, `Geometry`. */
+  def geometries: RDD[Feature[Geometry, ElementMeta]] = points.sparkContext.union(
+    points.map(identity), lines.map(identity), polygons.map(identity), multiPolys.map(identity)
+  )
+}

--- a/src/main/scala/vectorpipe/osm/internal/PlanetHistory.scala
+++ b/src/main/scala/vectorpipe/osm/internal/PlanetHistory.scala
@@ -28,7 +28,7 @@ private[vectorpipe] object PlanetHistory {
     val polys:  RDD[OSMPolygon] = lap.values.flatMap(identity)
 
     /* Depending on the dataset used, `Way` data may be incomplete. That is,
-     * the local version of a Way may have fewer Node references that the original
+     * the local version of a Way may have fewer Node references than the original
      * as found on OpenStreetMap. These usually occur along "dataset bounding
      * boxes" found in OSM subregion extracts, where a Polygon is cut in half by
      * the BBOX. The resulting Polygons, with only a subset of the original Nodes,

--- a/src/main/scala/vectorpipe/osm/internal/PlanetHistory.scala
+++ b/src/main/scala/vectorpipe/osm/internal/PlanetHistory.scala
@@ -14,10 +14,7 @@ import vectorpipe.osm._
 private[vectorpipe] object PlanetHistory {
 
   /** For all given Ways, associate with their Nodes to produce GeoTrellis Lines and Polygons. */
-  def features(
-    nodes: RDD[(Long, Node)],
-    ways: RDD[(Long, Way)]
-  ): (RDD[OSMPoint], RDD[OSMLine], RDD[OSMPolygon]) = {
+  def features(nodes: RDD[(Long, Node)], ways: RDD[(Long, Way)]): Features = {
 
     val (loneNodes, edges) = joinedWays(nodes, ways)
 
@@ -30,7 +27,17 @@ private[vectorpipe] object PlanetHistory {
     val lines:  RDD[OSMLine]    = lap.keys.flatMap(identity)
     val polys:  RDD[OSMPolygon] = lap.values.flatMap(identity)
 
-    (points, lines, polys)
+    /* Depending on the dataset used, `Way` data may be incomplete. That is,
+     * the local version of a Way may have fewer Node references that the original
+     * as found on OpenStreetMap. These usually occur along "dataset bounding
+     * boxes" found in OSM subregion extracts, where a Polygon is cut in half by
+     * the BBOX. The resulting Polygons, with only a subset of the original Nodes,
+     * are often self-intersecting. This causes Topology Exceptions during the
+     * clipping stage of the pipeline. Our only recourse is to remove them here.
+     *
+     * See: https://github.com/geotrellis/vectorpipe/pull/16#issuecomment-290144694
+     */
+    Features(points, lines, polys.filter(_.geom.isValid), points.sparkContext.emptyRDD)
   }
 
   /** Given one RDD of nodes and one of ways, produce:

--- a/src/main/scala/vectorpipe/osm/package.scala
+++ b/src/main/scala/vectorpipe/osm/package.scala
@@ -208,9 +208,9 @@ package object osm {
    */
   def snapshotFeatures(
     logError: (Feature[Line, ElementMeta] => String) => Feature[Line, ElementMeta] => Unit,
-    nodes: RDD[Node],
-    ways: RDD[Way],
-    relations: RDD[Relation]
+    nodes: RDD[(Long, Node)],
+    ways: RDD[(Long, Way)],
+    relations: RDD[(Long, Relation)]
   ): Features = {
 
     /* All Geometric OSM Relations.
@@ -218,9 +218,9 @@ package object osm {
      * Geometric Relations never appear in Relation Graphs. Therefore we can
      * naively grab them all here.
      */
-    val geomRelations: RDD[Relation] = relations.filter({ r =>
+    val geomRelations: RDD[(Long, Relation)] = relations.filter { case (_, r) =>
       r.meta.tags.get("type") === Some("multipolygon")
-    })
+    }
 
     val (points, rawLines, rawPolys) = E2F.geometries(nodes, ways)
 

--- a/src/main/tut/usage/osm.md
+++ b/src/main/tut/usage/osm.md
@@ -22,7 +22,7 @@ val path: String = "/some/path/on/your/machine/foo.osm"
 
 osm.fromLocalXML(path) match {
   case Failure(e) => { }  /* Parsing failed somehow... is the filepath correct? */
-  case Success((ns,ws,rs)) => { }  /* (RDD[Node], RDD[Way], RDD[Relation]) */
+  case Success((ns,ws,rs)) => { }  /* (RDD[(Long, Node)], RDD[(Long, Way)], RDD[(Long, Relation)]) */
 }
 
 sc.stop()
@@ -61,7 +61,7 @@ val path: String = "s3://bucket/key/foo.orc"
 
 osm.fromORC(path) match {
   case Failure(err) => { } /* Does the file exist? Do you have the right AWS credentials? */
-  case Success((ns,ws,rs)) => { } /* (RDD[Node], RDD[Way], RDD[Relation]) */
+  case Success((ns,ws,rs)) => { }  /* (RDD[(Long, Node)], RDD[(Long, Way)], RDD[(Long, Relation)]) */
 }
 
 ss.stop()

--- a/src/main/tut/usage/usage.md
+++ b/src/main/tut/usage/usage.md
@@ -22,14 +22,14 @@ val layout: LayoutDefinition =
   ZoomedLayoutScheme.layoutForZoom(15, WebMercator.worldExtent, 512)
 
 /* From an OSM data source, mocked as "empty" for this example */
-val (nodes, ways, relations): (RDD[osm.Node], RDD[osm.Way], RDD[osm.Relation]) =
+val (nodes, ways, relations): (RDD[(Long, osm.Node)], RDD[(Long, osm.Way)], RDD[(Long, osm.Relation)]) =
   (sc.emptyRDD, sc.emptyRDD, sc.emptyRDD)
 
 /* All OSM Elements lifted into GeoTrellis Geometry types.
- * Note: type OSMFeature = Feature[Geometry, Tree[ElementData]]
+ * Note: type OSMFeature = Feature[Geometry, ElementData]
  */
 val features: RDD[osm.OSMFeature] =
-  osm.toFeatures(VectorPipe.logToStdout, nodes, ways, relations)
+  osm.snapshotFeatures(VectorPipe.logToStdout, nodes, ways, relations).geometries
 
 /* All Geometries clipped to your `layout` grid */
 val featGrid: RDD[(SpatialKey, Iterable[osm.OSMFeature])] =


### PR DESCRIPTION
### TODO

- [x] `Features` type
- [x] Make both snapshot and historical APIs use `Features`
- [x] Fix microsite

### Motivation

This PR adds the `Features` type, a simple wrapper around the RDDs of various `Geometry` subtypes produced by the Elements-to-Features process. It's often the case that we want to inspect only a subset of the recreated features ("roads only", for instance). In these cases, we don't want to bother with Spark processing all the extra Points and Polygons. With the `Features` wrapper, it no longer will.

`Features` exposes the function `geometries: Features => RDD[OSMFeature]` as the glue to the rest of the VectorTile creation process, since the next step wants generic `OSMFeature`s.

The results of this PR should improve performance for OSMesa analytics generation, as well as other Azavea ingests that involve OSM data.