### PR TITLE
More Information for the publishSettings

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -88,7 +88,13 @@ val common = Seq(
 
 val release = Seq(
   bintrayOrganization := Some("azavea"),
-  licenses += ("Apache-2.0", url("http://apache.org/licenses/LICENSE-2.0"))
+  bintrayRepository := "maven",
+  bintrayVcsUrl := Some("https://github.com/geotrellis/vectorpipe.git"),
+  publishMavenStyle := true,
+  publishArtifact in Test := false,
+  pomIncludeRepository := { _ => false },
+  licenses += ("Apache-2.0", url("http://apache.org/licenses/LICENSE-2.0")),
+  homepage := Some(url("https://geotrellis.github.io/vectorpipe/"))
 )
 
 lazy val lib = project.in(file(".")).settings(common, release)


### PR DESCRIPTION
This PR adds more settings to the `publishSettings` in the `build.sbt`. This was done because before it was not possible to publish directly to binTray from `sbt` due to not having the the `binTrayRepository` set.