### PR TITLE
Define a Full component for the LayerMetadata object

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,8 @@
 .ensime_cache/*
 clipping/*
 osmosis/*
+.idea
+target
 
 derby.log
 metastore_db/*

--- a/src/main/scala/vectorpipe/LayerMetadata.scala
+++ b/src/main/scala/vectorpipe/LayerMetadata.scala
@@ -3,7 +3,8 @@ package vectorpipe
 import geotrellis.spark._
 import geotrellis.spark.io._
 import geotrellis.spark.tiling.LayoutDefinition
-import geotrellis.util.GetComponent
+import geotrellis.util.Component
+
 import spray.json._
 import spray.json.DefaultJsonProtocol._
 
@@ -14,9 +15,15 @@ case class LayerMetadata[K: JsonFormat](layout: LayoutDefinition, bounds: KeyBou
 
 object LayerMetadata {
 
-  /** A Lens into the key bounds. */
-  implicit def metaGet[K]: GetComponent[LayerMetadata[K], Bounds[K]] =
-    GetComponent(_.bounds)
+  /** A Lens into and from the key bounds. */
+  implicit def metaComponent[K: JsonFormat]: Component[LayerMetadata[K], Bounds[K]] =
+    Component[LayerMetadata[K], Bounds[K]](
+      _.bounds,
+      (md, bounds) => bounds match {
+        case kb: KeyBounds[K] => md.copy(bounds = kb)
+        case _ => md
+      }
+    )
 
   /** Json Conversion. */
   implicit def metaFormat[K: JsonFormat]: RootJsonFormat[LayerMetadata[K]] =


### PR DESCRIPTION
This fix makes possible the following code usage:

```scala
package vectorpipe

import geotrellis.spark._
import geotrellis.spark.tiling._
import geotrellis.spark.io._
import geotrellis.spark.io.file._
import geotrellis.spark.SpatialKey._
import geotrellis.spark.io.index.ZCurveKeyIndexMethod
import geotrellis.vector.{Feature, Geometry}
import geotrellis.vectortile.VectorTile
import geotrellis.util._

import org.apache.spark.rdd.RDD

object Test {
  val layout: LayoutDefinition = ???
  // val featGrid: RDD[(SpatialKey, Iterable[Feature[Geometry, String]])] = ???

  val tiles: RDD[(SpatialKey, VectorTile)] =
    vectortiles(Collate.byOSM, layout, null)

  val bounds: KeyBounds[SpatialKey] =
    tiles.map({ case (key, _) => KeyBounds(key, key) }).reduce(_ combine _)

  /* Construct metadata for the Layer */
  import vectorpipe.LayerMetadata._
  val meta = LayerMetadata(layout, bounds)

  /* Write the tiles */
  val writer = FileLayerWriter(FileAttributeStore("E:\\OSM\\layer"))

  // WARN: writer requires the entire Component lens and not only getter
  writer.write(LayerId("myFirstLayer", 14), ContextRDD(tiles, meta), ZCurveKeyIndexMethod)
}

```

Thx for the report to @120534 