### PR TITLE
Mark loggers and UDFs as transient lazy

### DIFF
--- a/src/main/scala/vectorpipe/functions/osm/package.scala
+++ b/src/main/scala/vectorpipe/functions/osm/package.scala
@@ -144,7 +144,7 @@ package object osm {
         matchingKeys.exists(k => !AreaKeys(k).contains(tags(k)))
     }
 
-  val isAreaUDF: UserDefinedFunction = udf(_isArea)
+  @transient lazy val isAreaUDF: UserDefinedFunction = udf(_isArea)
 
   def isArea(tags: Column): Column =
     when(lower(coalesce(tags.getField("area"), lit(""))).isin(BooleanValues: _*),
@@ -178,7 +178,7 @@ package object osm {
       Row(t, ref, role)
     }
 
-  lazy val compressMemberTypes: UserDefinedFunction = udf(_compressMemberTypes, MemberSchema)
+  @transient lazy val compressMemberTypes: UserDefinedFunction = udf(_compressMemberTypes, MemberSchema)
 
   /**
    * Checks if members have byte-encoded types
@@ -221,7 +221,7 @@ package object osm {
   private val ContentMatcher: Regex = """[\p{L}\uD83C-\uDBFF\uDC00-\uDFFF]""".r
   private val TrailingPunctuationMatcher: Regex = """[:]$""".r
 
-  val extractHashtags: UserDefinedFunction = udf { comment: String =>
+  @transient lazy val extractHashtags: UserDefinedFunction = udf { comment: String =>
     HashtagMatcher
       .findAllMatchIn(comment)
       // fetch the first group (after #)
@@ -242,7 +242,7 @@ package object osm {
   def isBuilding(tags: Column): Column =
     lower(coalesce(tags.getItem("building"), lit("no"))) =!= "no" as 'isBuilding
 
-  val isPOI: UserDefinedFunction = udf {
+  @transient lazy val isPOI: UserDefinedFunction = udf {
     tags: Map[String, String] => POITags.intersect(tags.keySet).nonEmpty
   }
 

--- a/src/main/scala/vectorpipe/functions/package.scala
+++ b/src/main/scala/vectorpipe/functions/package.scala
@@ -11,9 +11,9 @@ package object functions {
   // Spark functions are typically defined using snake_case, therefore so are the UDFs
   // internal helper functions use standard Scala naming conventions
 
-  lazy val merge_counts: UserDefinedFunction = udf(_mergeCounts)
+  @transient lazy val merge_counts: UserDefinedFunction = udf(_mergeCounts)
 
-  lazy val sum_counts: UserDefinedFunction = udf { counts: Iterable[Map[String, Int]] =>
+  @transient lazy val sum_counts: UserDefinedFunction = udf { counts: Iterable[Map[String, Int]] =>
     counts.reduce(_mergeCounts(_, _))
   }
 
@@ -29,23 +29,23 @@ package object functions {
     when(value.isNotNull, value.cast(FloatType))
       .otherwise(lit(Float.NaN)) as s"asFloat($value)"
 
-  val count_values: UserDefinedFunction = udf {
+  @transient lazy val count_values: UserDefinedFunction = udf {
     (_: Seq[String]).groupBy(identity).mapValues(_.size)
   }
 
-  val flatten: UserDefinedFunction = udf {
+  @transient lazy val flatten: UserDefinedFunction = udf {
     (_: Seq[Seq[String]]).flatten
   }
 
-  val flatten_set: UserDefinedFunction = udf {
+  @transient lazy val flatten_set: UserDefinedFunction = udf {
     (_: Seq[Seq[String]]).flatten.distinct
   }
 
-  val merge_sets: UserDefinedFunction = udf { (a: Iterable[String], b: Iterable[String]) =>
+  @transient lazy val merge_sets: UserDefinedFunction = udf { (a: Iterable[String], b: Iterable[String]) =>
     (Option(a).getOrElse(Set.empty).toSet ++ Option(b).getOrElse(Set.empty).toSet).toArray
   }
 
-  val without: UserDefinedFunction = udf { (list: Seq[String], without: String) =>
+  @transient lazy val without: UserDefinedFunction = udf { (list: Seq[String], without: String) =>
     list.filterNot(x => x == without)
   }
 

--- a/src/main/scala/vectorpipe/internal/package.scala
+++ b/src/main/scala/vectorpipe/internal/package.scala
@@ -22,7 +22,7 @@ package object internal {
   val RelationType: Byte = 3
   val MultiPolygonRoles: Seq[String] = Set("", "outer", "inner").toSeq
 
-  lazy val logger: Logger = Logger.getLogger(getClass)
+  @transient lazy val logger: Logger = Logger.getLogger(getClass)
 
   lazy val BareElementSchema = StructType(
     StructField("changeset", LongType, nullable = false) ::

--- a/src/main/scala/vectorpipe/relations/MultiPolygons.scala
+++ b/src/main/scala/vectorpipe/relations/MultiPolygons.scala
@@ -7,7 +7,7 @@ import org.apache.log4j.Logger
 import vectorpipe.internal.WayType
 
 object MultiPolygons {
-  private lazy val logger = Logger.getLogger(getClass)
+  @transient private lazy val logger = Logger.getLogger(getClass)
   val prepGeomFactory = new PreparedGeometryFactory
 
   def build(id: Long,

--- a/src/main/scala/vectorpipe/relations/Routes.scala
+++ b/src/main/scala/vectorpipe/relations/Routes.scala
@@ -6,7 +6,7 @@ import org.apache.log4j.Logger
 import vectorpipe.internal.WayType
 
 object Routes {
-  private lazy val logger = Logger.getLogger(getClass)
+  @transient private lazy val logger = Logger.getLogger(getClass)
 
   def build(id: Long,
             version: Int,

--- a/src/main/scala/vectorpipe/vectortile/package.scala
+++ b/src/main/scala/vectorpipe/vectortile/package.scala
@@ -22,9 +22,9 @@ package object vectortile {
   case class SingleLayer(val name: String) extends LayerMultiplicity
   case class LayerNamesInColumn(val name: String) extends LayerMultiplicity
 
-  val logger = org.apache.log4j.Logger.getRootLogger
+  @transient lazy val logger = org.apache.log4j.Logger.getRootLogger
 
-  val st_reprojectGeom = udf { (g: jts.Geometry, srcProj: String, destProj: String) =>
+  @transient lazy val st_reprojectGeom = udf { (g: jts.Geometry, srcProj: String, destProj: String) =>
     val trans = Proj4Transform(CRS.fromString(srcProj), CRS.fromString(destProj))
     val gt = Geometry(g)
     gt.reproject(trans).jtsGeom


### PR DESCRIPTION
So that they are all serialized correctly for Spark jobs.

Finally got around to cleaning up the diff in #69 and checking for other udf declarations at the object level. I _think_ I got them all? It would be worth a second eye to grep for missed instances.

Closes #69 