### PR TITLE
Consistently strip leading + trailing slash from S3 URI prefix in export

### DIFF
--- a/src/main/scala/vectorpipe/vectortile/export/package.scala
+++ b/src/main/scala/vectorpipe/vectortile/export/package.scala
@@ -17,7 +17,7 @@ package object export {
     uri.getScheme match {
       case "s3" =>
         val path = uri.getPath
-        val prefix = if (path.last == '/') { path.drop(1) } else { path.slice(1, path.length - 1) }
+        val prefix = path.stripPrefix("/").stripSuffix("/")
         saveToS3(vectorTiles, zoom, uri.getAuthority, prefix)
       case _ =>
         saveHadoop(vectorTiles, zoom, uri)


### PR DESCRIPTION
I noticed while I was exporting tilesets to S3 that when I passed in a URI such as:
```
s3://geotrellis-test/foo/tiles-v01
```
that the tiles were saving to:
```
s3://geotrellis-test/foo/tiles-v0
```

As far as I can tell, it looks like the original intent of this code is to strip both leading and trailing slashes...or at least that's what works consistently when I pass URIs to `saveToS3`. So I modified the code to always remove leading + trailing slashes and to not accidentally remove other stuff.