### PR TITLE
Add RELEASING.md and a changelog

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,22 @@
+# Overview
+
+Brief description of what this PR does and why it's important
+
+## Demo
+
+Optional. Screenshots, etc. 
+
+## Notes
+
+Optional. Extra context, ancillary topics, alternative strategies that didn't work out, etc.
+
+## Testing Instructions
+
+Optional. Include if there's more specifics than "CI tests should pass".
+
+## Checklist
+
+- [ ] Add entry to CHANGELOG.md 
+
+Closes #XXX
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+### Added
+- RELEASING.md - Instructions for releasing new versions of this project
+
+## [1.0.0-RC3] - 2019-04-24
+### Fixed
+- Mark all logger vals and some UDF vals as @transient lazy to avoid Spark serialization issues
+- Properly strip leading and trailing slashes from S3 URIs when exporting vector tiles
+

--- a/README.md
+++ b/README.md
@@ -182,20 +182,3 @@ lazy val mainRunner = project.in(file("mainRunner")).dependsOn(RootProject(file(
 )
 ```
 
-## Publishing Releases
-
-To follow the checklist below, you'll need to ensure you have write access 
-to the `azavea` bintray organization.
-
-Then:
-
-- [ ] Create a new release branch, e.g. `release/x.y.z`
-- [ ] Bump version refs in README
-- [ ] Bump version ref in `project/Version.scala`
-- [ ] Push branch and make a PR on GitHub
-- [ ] Ensure CI succeeds
-- [ ] Merge release branch after CI succeeds
-- [ ] `./sbt publish` from up to date master after merge
-- [ ] `git tag -a vx.y.z -m "Release x.y.z"`
-- [ ] `git push --tags`
-

--- a/README.md
+++ b/README.md
@@ -181,3 +181,21 @@ lazy val mainRunner = project.in(file("mainRunner")).dependsOn(RootProject(file(
   )
 )
 ```
+
+## Publishing Releases
+
+To follow the checklist below, you'll need to ensure you have write access 
+to the `azavea` bintray organization.
+
+Then:
+
+- [ ] Create a new release branch, e.g. `release/x.y.z`
+- [ ] Bump version refs in README
+- [ ] Bump version ref in `project/Version.scala`
+- [ ] Push branch and make a PR on GitHub
+- [ ] Ensure CI succeeds
+- [ ] Merge release branch after CI succeeds
+- [ ] `./sbt publish` from up to date master after merge
+- [ ] `git tag -a vx.y.z -m "Release x.y.z"`
+- [ ] `git push --tags`
+

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -9,6 +9,7 @@ following the prompts after running `./sbt bintrayChangeCredentials`
 1. Create a new release branch from up-to-date master, e.g. `release/x.y.z`
 1. Bump version refs in README
 1. Bump version ref in `project/Version.scala`
+1. Review CHANGELOG.md. Move `[Unreleased]` header to empty section and replace with `[x.y.z]` header plus release date. 
 1. Commit these changes as a single commit, with the message "Release vx.y.z"
 1. Push branch and make a PR on GitHub
 1. Ensure CI succeeds

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,19 @@
+# Releasing
+
+When releasing, ensure you have write access to the `azavea` 
+bintray organization. You can configure your credentials by
+following the prompts after running `./sbt bintrayChangeCredentials`
+
+## Publishing a release
+
+1. Create a new release branch from up-to-date master, e.g. `release/x.y.z`
+1. Bump version refs in README
+1. Bump version ref in `project/Version.scala`
+1. Commit these changes as a single commit, with the message "Release vx.y.z"
+1. Push branch and make a PR on GitHub
+1. Ensure CI succeeds
+1. Ensure there are no new commits on master, then merge. If there are new commits, rebase this branch on master and start over at step 2 if you wish to include them.
+1. Tag the merge commit: `git tag -a vx.y.z -m "Release x.y.z"`
+1. Publish the tagged commit as a new release: `./sbt publish`
+1. Push the new tag: `git push --tags`
+


### PR DESCRIPTION
# Overview

I had started this after the 1.0.0-RC3 release and so when the discussion happened in #78 and #79 got created, that provided an additional kick to clean up and PR my notes right away.

There's also a CHANGELOG in here, I'm open to keeping or discarding whichever changes you all feel are most appropriate at this time.

@mojodna I attempted to adjust my list to match the suggested workflow you provided in https://github.com/geotrellis/vectorpipe/pull/78#issuecomment-486362399, as I like that better than what I did for RC3 (I attached the RC3 tag to master after merging the PR). The git flow paradigm essentially follows the bullets you laid out.

Closes #79 
Closes #77 
