### PR TITLE
Preserve deleted coordinates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
 ### Added
+
 - RELEASING.md - Instructions for releasing new versions of this project
+- Preserve the last-known coordinates of deleted nodes
 
 ## [1.0.0-RC3] - 2019-04-24
+
 ### Fixed
+
 - Mark all logger vals and some UDF vals as @transient lazy to avoid Spark serialization issues
 - Properly strip leading and trailing slashes from S3 URIs when exporting vector tiles
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - RELEASING.md - Instructions for releasing new versions of this project
 - Preserve the last-known coordinates of deleted nodes
+- Convert coordinates to Doubles (expected by VP internals) when pre-processing
 
 ## [1.0.0-RC3] - 2019-04-24
 

--- a/src/main/scala/vectorpipe/internal/package.scala
+++ b/src/main/scala/vectorpipe/internal/package.scala
@@ -97,8 +97,8 @@ package object internal {
           when(!'visible and (lag('tags, 1) over idByVersion).isNotNull,
             lag('tags, 1) over idByVersion)
             .otherwise('tags) as 'tags,
-          when(!'visible, lit(Double.NaN)).otherwise('lat) as 'lat,
-          when(!'visible, lit(Double.NaN)).otherwise('lon) as 'lon,
+          when(!'visible, lag('lat, 1) over idByVersion).otherwise('lat) as 'lat,
+          when(!'visible, lag('lon, 1) over idByVersion).otherwise('lon) as 'lon,
           'changeset,
           'timestamp,
           (lead('timestamp, 1) over idByVersion) as 'validUntil,

--- a/src/main/scala/vectorpipe/internal/package.scala
+++ b/src/main/scala/vectorpipe/internal/package.scala
@@ -13,6 +13,7 @@ import org.apache.spark.sql.functions._
 import org.apache.spark.sql.jts.GeometryUDT
 import org.apache.spark.sql.types._
 import org.locationtech.geomesa.spark.jts._
+import vectorpipe.functions.asDouble
 import vectorpipe.functions.osm._
 import vectorpipe.relations.{MultiPolygons, Routes}
 
@@ -92,6 +93,8 @@ package object internal {
       filteredHistory
         .where('type === "node")
         .repartition('id)
+        .withColumn("lat", asDouble('lat))
+        .withColumn("lon", asDouble('lon))
         .select(
           'id,
           when(!'visible and (lag('tags, 1) over idByVersion).isNotNull,
@@ -323,7 +326,7 @@ package object internal {
               case coords if coords.length == 1 =>
                 Some(GeomFactory.factory.createPoint(new jts.Coordinate(coords.head.head, coords.head.last)))
               case coords => {
-                val coordinates = coords.map(xy => new jts.Coordinate(xy.head.toDouble, xy.last.toDouble)).toArray
+                val coordinates = coords.map(xy => new jts.Coordinate(xy.head, xy.last)).toArray
                 val line = GeomFactory.factory.createLineString(coordinates)
 
                 if (isArea && line.getNumPoints >= 4 && line.isClosed)

--- a/src/test/scala/vectorpipe/vectortile/PipelineSpec.scala
+++ b/src/test/scala/vectorpipe/vectortile/PipelineSpec.scala
@@ -1,16 +1,10 @@
 package vectorpipe.vectortile
 
 import org.apache.spark.sql.functions
-import org.apache.spark.sql.functions.{col, isnull, lit}
-import org.apache.spark.sql.types._
+import org.apache.spark.sql.functions.{isnull, lit}
 import org.locationtech.geomesa.spark.jts._
-import org.locationtech.jts.{geom => jts}
-
-import vectorpipe.TestEnvironment
-import vectorpipe._
-import vectorpipe.{internal => vp}
-
 import org.scalatest._
+import vectorpipe.{TestEnvironment, internal => vp, _}
 
 class PipelineSpec extends FunSpec with TestEnvironment with Matchers {
   import ss.implicits._
@@ -20,7 +14,7 @@ class PipelineSpec extends FunSpec with TestEnvironment with Matchers {
   val df = ss.read.orc(orcFile)
 
   describe("Vectortile Pipelines") {
-    val nodes = vp.preprocessNodes(df, None).cache
+    val nodes = vp.preprocessNodes(df, None)
 
     val nodeGeoms = nodes
       .filter(functions.not(isnull('lat)))


### PR DESCRIPTION
# Overview

It can be helpful to know where a node was located immediately prior to deletion. It being no longer visible should serve as an indication not to use these coordinates unless needed.

## Checklist

- [x] Add entry to CHANGELOG.md 

