### PR TITLE
Resolve commons-io deprecation warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - RELEASING.md - Instructions for releasing new versions of this project
+- Resolve commons-io deprecation warnings
 
 ## [1.0.0-RC3] - 2019-04-24
 ### Fixed

--- a/src/main/scala/vectorpipe/sources/ChangesetSource.scala
+++ b/src/main/scala/vectorpipe/sources/ChangesetSource.scala
@@ -2,6 +2,7 @@ package vectorpipe.sources
 
 import java.io.{ByteArrayInputStream, IOException}
 import java.net.URI
+import java.nio.charset.StandardCharsets
 import java.util.zip.GZIPInputStream
 
 import cats.implicits._
@@ -46,7 +47,7 @@ object ChangesetSource extends Logging {
         val bais = new ByteArrayInputStream(response.body)
         val gzis = new GZIPInputStream(bais)
         try {
-          val data = XML.loadString(IOUtils.toString(gzis))
+          val data = XML.loadString(IOUtils.toString(gzis, StandardCharsets.UTF_8))
 
           val changesets = (data \ "changeset").map(Changeset.fromXML(_, sequence))
 


### PR DESCRIPTION
# Overview

`IOUtils.toString` without a character set has been deprecated.

## Checklist

- [x] Add entry to CHANGELOG.md 
