### PR TITLE
Fetch gzipped augmented diff JSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - RELEASING.md - Instructions for releasing new versions of this project
 - Sync with [id-area-keys@2.13.0](https://github.com/osmlab/id-area-keys/blob/v2.13.0/areaKeys.json) for determining area-ness of a way.
+- Fetch gzipped augmented diff JSON (produced by [overpass-diff-publisher](https://github.com/mojodna/overpass-diff-publisher))
 
 ## [1.0.0-RC3] - 2019-04-24
  

--- a/src/main/scala/vectorpipe/sources/AugmentedDiffSource.scala
+++ b/src/main/scala/vectorpipe/sources/AugmentedDiffSource.scala
@@ -1,8 +1,9 @@
 package vectorpipe.sources
 
-import java.io.File
+import java.io.{ByteArrayInputStream, File}
 import java.net.URI
 import java.nio.charset.StandardCharsets
+import java.util.zip.GZIPInputStream
 
 import cats.implicits._
 import com.amazonaws.services.s3.model.AmazonS3Exception
@@ -30,23 +31,34 @@ object AugmentedDiffSource extends Logging {
   def getSequence(baseURI: URI, sequence: Int): Seq[AugmentedDiff] = {
     val bucket = baseURI.getHost
     val prefix = new File(baseURI.getPath.drop(1)).toPath
-    val key = prefix.resolve(s"$sequence.json").toString
+    // left-pad sequence
+    val s = f"$sequence%09d"
+    val key = prefix.resolve(s"${s.slice(0, 3)}/${s.slice(3, 6)}/${s.slice(6, 9)}.json.gz").toString
 
     logDebug(s"Fetching sequence $sequence")
-    try {
-      IOUtils
-        .toString(s3.readBytes(bucket, key), StandardCharsets.UTF_8.toString)
-        .lines
-        .map { line =>
-          // Spark doesn't like RS-delimited JSON; perhaps Spray doesn't either
-          val features = line
-            .replace("\u001e", "")
-            .parseGeoJson[JsonFeatureCollectionMap]
-            .getAll[Feature[Geometry, ElementWithSequence]]
 
-          AugmentedDiff(sequence, features.get("old"), features("new"))
-        }
-        .toSeq
+    try {
+      val bais = new ByteArrayInputStream(s3.readBytes(bucket, key))
+      val gzis = new GZIPInputStream(bais)
+
+      try {
+        IOUtils
+          .toString(gzis, StandardCharsets.UTF_8)
+          .lines
+          .map { line =>
+            // Spark doesn't like RS-delimited JSON; perhaps Spray doesn't either
+            val features = line
+              .replace("\u001e", "")
+              .parseGeoJson[JsonFeatureCollectionMap]
+              .getAll[Feature[Geometry, ElementWithSequence]]
+
+            AugmentedDiff(sequence, features.get("old"), features("new"))
+          }
+          .toSeq
+      } finally {
+        gzis.close()
+        bais.close()
+      }
     } catch {
       case e: AmazonS3Exception if e.getStatusCode == 404 || e.getStatusCode == 403 =>
         getCurrentSequence(baseURI) match {

--- a/src/main/scala/vectorpipe/sources/ChangeSource.scala
+++ b/src/main/scala/vectorpipe/sources/ChangeSource.scala
@@ -20,9 +20,8 @@ object ChangeSource extends Logging {
   private val saxParserFactory = SAXParserFactory.newInstance
 
   def getSequence(baseURI: URI, sequence: Int): Seq[Change] = {
-    val s = f"$sequence%09d".toArray
-    val path =
-      s"${s.slice(0, 3).mkString}/${s.slice(3, 6).mkString}/${s.slice(6, 9).mkString}.osc.gz"
+    val s = f"$sequence%09d"
+    val path = s"${s.slice(0, 3)}/${s.slice(3, 6)}/${s.slice(6, 9)}.osc.gz"
 
     logInfo(s"Fetching sequence $sequence")
 

--- a/src/main/scala/vectorpipe/sources/ChangesetSource.scala
+++ b/src/main/scala/vectorpipe/sources/ChangesetSource.scala
@@ -27,9 +27,8 @@ object ChangesetSource extends Logging {
     Decoder.instance(a => a.as[String].map(DateTime.parse(_, formatter)))
 
   def getSequence(baseURI: URI, sequence: Int): Seq[Changeset] = {
-    val s = f"$sequence%09d".toArray
-    val path =
-      s"${s.slice(0, 3).mkString}/${s.slice(3, 6).mkString}/${s.slice(6, 9).mkString}.osm.gz"
+    val s = f"$sequence%09d"
+    val path = s"${s.slice(0, 3)}/${s.slice(3, 6)}/${s.slice(6, 9)}.osm.gz"
 
     logDebug(s"Fetching sequence $sequence")
 


### PR DESCRIPTION
# Overview

This lines up with the current approach to generating augmented diffs in overpass-diff-publisher. (Uncompressed diffs are still produced, but deprecated until this change can be rolled out.)

## Checklist

- [x] Add entry to CHANGELOG.md 

Refs https://github.com/azavea/osmesa/issues/122
