### PR TITLE
Support for semicolon-delimited values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - RELEASING.md - Instructions for releasing new versions of this project
+- Support for semicolon-delimited tag values in UDFs, e.g. `shop=bakery;dairy`
 
 ### Changed
 
 - Sync with [id-area-keys@2.13.0](https://github.com/osmlab/id-area-keys/blob/v2.13.0/areaKeys.json) for determining area-ness of a way.
 - Fetch gzipped augmented diff JSON (produced by [overpass-diff-publisher](https://github.com/mojodna/overpass-diff-publisher))
 - Preserve the last-known coordinates of deleted nodes
+- Better handling of falsy boolean values in tag UDFs
+- Adds `riverbank`, `stream_end`, `dam`, `weir`, `waterfall`, and `pressurised`
+  to the list of waterway features
 
 ### Fixed
 

--- a/src/test/scala/vectorpipe/functions/osm/FunctionSpec.scala
+++ b/src/test/scala/vectorpipe/functions/osm/FunctionSpec.scala
@@ -19,7 +19,11 @@ class FunctionSpec extends FunSpec with TestEnvironment with Matchers {
         Map("area" -> "no") -> false,
         Map("area" -> "no") -> false,
         Map("area" -> "0") -> false,
-        Map("area" -> "something") -> false
+        Map("area" -> "something") -> false,
+        Map("area" -> "yes;no") -> true,
+        Map("area" -> "yes; no") -> true,
+        Map("area" -> "yes ; no") -> true,
+        Map("area" -> "yes ;no") -> true
       )
         .toDF("tags", "value")
         .where(isArea('tags) =!= 'value)
@@ -30,7 +34,10 @@ class FunctionSpec extends FunSpec with TestEnvironment with Matchers {
       Seq(
         Map("office" -> "architect") -> true,
         Map("waterway" -> "riverbank") -> true,
-        Map("waterway" -> "canal") -> false
+        Map("waterway" -> "canal") -> false,
+        Map("aeroway" -> "aerodrome;apron") -> true,
+        Map("aeroway" -> "aerodrome ; runway") -> true,
+        Map("aeroway" -> "taxiway;runway") -> false
       )
         .toDF("tags", "value")
         .where(isArea('tags) =!= 'value)
@@ -43,7 +50,9 @@ class FunctionSpec extends FunSpec with TestEnvironment with Matchers {
       Seq(
         Map("type" -> "multipolygon") -> true,
         Map("type" -> "boundary") -> true,
-        Map("type" -> "route") -> false
+        Map("type" -> "route") -> false,
+        Map("type" -> "multipolygon;boundary") -> true,
+        Map("type" -> "multipolygon ; boundary") -> true
       )
         .toDF("tags", "value")
         .where(isMultiPolygon('tags) =!= 'value)
@@ -56,7 +65,9 @@ class FunctionSpec extends FunSpec with TestEnvironment with Matchers {
       Seq(
         Map("type" -> "multipolygon") -> false,
         Map("type" -> "boundary") -> false,
-        Map("type" -> "route") -> true
+        Map("type" -> "route") -> true,
+        Map("type" -> "route;boundary") -> true,
+        Map("type" -> "route ; boundary") -> true
       )
         .toDF("tags", "value")
         .where(isRoute('tags) =!= 'value)
@@ -70,7 +81,8 @@ class FunctionSpec extends FunSpec with TestEnvironment with Matchers {
         Map("building" -> "yes") -> true,
         Map("building" -> "no") -> false,
         Map("building" -> "false") -> false,
-        Map("building" -> "farm") -> true
+        Map("building" -> "farm") -> true,
+        Map("building" -> "farm;apartments") -> true
       )
         .toDF("tags", "value")
         .where(isBuilding('tags) =!= 'value)
@@ -87,7 +99,8 @@ class FunctionSpec extends FunSpec with TestEnvironment with Matchers {
         Map("office" -> "architect") -> true,
         Map("leisure" -> "disc_golf_course") -> true,
         Map("aeroway" -> "aerodrome") -> true,
-        Map("highway" -> "motorway") -> false
+        Map("highway" -> "motorway") -> false,
+        Map("shop" -> "bakery ; dairy") -> true
       )
         .toDF("tags", "value")
         .where(isPOI('tags) =!= 'value)
@@ -100,6 +113,7 @@ class FunctionSpec extends FunSpec with TestEnvironment with Matchers {
       Seq(
         Map("highway" -> "motorway") -> true,
         Map("highway" -> "path") -> true,
+        Map("highway" -> "path ;footway") -> true,
         Map("building" -> "yes") -> false
       )
         .toDF("tags", "value")
@@ -109,10 +123,11 @@ class FunctionSpec extends FunSpec with TestEnvironment with Matchers {
   }
 
   describe("isCoastline") {
-    it("marks roads appropriately") {
+    it("marks coastline appropriately") {
       Seq(
         Map("natural" -> "coastline") -> true,
-        Map("natural" -> "water") -> false
+        Map("natural" -> "water") -> false,
+        Map("natural" -> "coastline ; water") -> true
       )
         .toDF("tags", "value")
         .where(isCoastline('tags) =!= 'value)
@@ -134,7 +149,9 @@ class FunctionSpec extends FunSpec with TestEnvironment with Matchers {
         Map("waterway" -> "weir") -> true,
         Map("waterway" -> "waterfall") -> true,
         Map("waterway" -> "pressurised") -> true,
-        Map("waterway" -> "fuel") -> false
+        Map("waterway" -> "fuel") -> false,
+        Map("waterway" -> "canal ; stream") -> true,
+        Map("waterway" -> "canal ; fuel") -> true
       )
         .toDF("tags", "value")
         .where(isWaterway('tags) =!= 'value)

--- a/src/test/scala/vectorpipe/functions/osm/FunctionSpec.scala
+++ b/src/test/scala/vectorpipe/functions/osm/FunctionSpec.scala
@@ -1,0 +1,144 @@
+package vectorpipe.functions.osm
+
+import org.scalatest.{FunSpec, Matchers}
+import vectorpipe.TestEnvironment
+
+class FunctionSpec extends FunSpec with TestEnvironment with Matchers {
+
+  import ss.implicits._
+
+  describe("isArea") {
+    it("marks 'area=*' appropriately") {
+      Seq(
+        Map("area" -> "yes") -> true,
+        Map("area" -> "YES") -> true,
+        Map("area" -> "YeS") -> true,
+        Map("area" -> "1") -> true,
+        Map("area" -> "true") -> true,
+        Map("area" -> "True") -> true,
+        Map("area" -> "no") -> false,
+        Map("area" -> "no") -> false,
+        Map("area" -> "0") -> false,
+        Map("area" -> "something") -> false
+      )
+        .toDF("tags", "value")
+        .where(isArea('tags) =!= 'value)
+        .count should equal(0)
+    }
+
+    it("respects area-keys") {
+      Seq(
+        Map("office" -> "architect") -> true,
+        Map("waterway" -> "riverbank") -> true,
+        Map("waterway" -> "canal") -> false
+      )
+        .toDF("tags", "value")
+        .where(isArea('tags) =!= 'value)
+        .count should equal(0)
+    }
+  }
+
+  describe("isMultiPolygon") {
+    it("marks multipolygons and boundaries appropriately") {
+      Seq(
+        Map("type" -> "multipolygon") -> true,
+        Map("type" -> "boundary") -> true,
+        Map("type" -> "route") -> false
+      )
+        .toDF("tags", "value")
+        .where(isMultiPolygon('tags) =!= 'value)
+        .count should equal(0)
+    }
+  }
+
+  describe("isRoute") {
+    it("marks routes appropriately") {
+      Seq(
+        Map("type" -> "multipolygon") -> false,
+        Map("type" -> "boundary") -> false,
+        Map("type" -> "route") -> true
+      )
+        .toDF("tags", "value")
+        .where(isRoute('tags) =!= 'value)
+        .count should equal(0)
+    }
+  }
+
+  describe("isBuilding") {
+    it("marks buildings appropriately") {
+      Seq(
+        Map("building" -> "yes") -> true,
+        Map("building" -> "no") -> false,
+        Map("building" -> "false") -> false,
+        Map("building" -> "farm") -> true
+      )
+        .toDF("tags", "value")
+        .where(isBuilding('tags) =!= 'value)
+        .count should equal(0)
+    }
+  }
+
+  describe("isPOI") {
+    it("marks POIs appropriately") {
+      Seq(
+        Map("amenity" -> "cafe") -> true,
+        Map("shop" -> "bakery") -> true,
+        Map("craft" -> "bakery") -> true,
+        Map("office" -> "architect") -> true,
+        Map("leisure" -> "disc_golf_course") -> true,
+        Map("aeroway" -> "aerodrome") -> true,
+        Map("highway" -> "motorway") -> false
+      )
+        .toDF("tags", "value")
+        .where(isPOI('tags) =!= 'value)
+        .count should equal(0)
+    }
+  }
+
+  describe("isRoad") {
+    it("marks roads appropriately") {
+      Seq(
+        Map("highway" -> "motorway") -> true,
+        Map("highway" -> "path") -> true,
+        Map("building" -> "yes") -> false
+      )
+        .toDF("tags", "value")
+        .where(isRoad('tags) =!= 'value)
+        .count should equal(0)
+    }
+  }
+
+  describe("isCoastline") {
+    it("marks roads appropriately") {
+      Seq(
+        Map("natural" -> "coastline") -> true,
+        Map("natural" -> "water") -> false
+      )
+        .toDF("tags", "value")
+        .where(isCoastline('tags) =!= 'value)
+        .count should equal(0)
+    }
+  }
+
+  describe("isWaterway") {
+    it("marks waterways appropriately") {
+      Seq(
+        Map("waterway" -> "river") -> true,
+        Map("waterway" -> "riverbank") -> true,
+        Map("waterway" -> "canal") -> true,
+        Map("waterway" -> "stream") -> true,
+        Map("waterway" -> "brook") -> true,
+        Map("waterway" -> "drain") -> true,
+        Map("waterway" -> "ditch") -> true,
+        Map("waterway" -> "dam") -> true,
+        Map("waterway" -> "weir") -> true,
+        Map("waterway" -> "waterfall") -> true,
+        Map("waterway" -> "pressurised") -> true,
+        Map("waterway" -> "fuel") -> false
+      )
+        .toDF("tags", "value")
+        .where(isWaterway('tags) =!= 'value)
+        .count should equal(0)
+    }
+  }
+}


### PR DESCRIPTION
# Overview

Semicolon-delimited values are how tags with multiple values are represented in OSM. E.g. `shop=bakery;dairy` for a shop that sells both baked goods and dairy products.

When at least one value matches, the corresponding UDF returns `true`.

This also improves handling of falsy boolean values and expands the universe of waterway features.

Oh, and woo, tests.

## Checklist

- [x] Add entry to CHANGELOG.md 
