### PR TITLE
Populate deleted nds and members from previous version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Better handling of falsy boolean values in tag UDFs
 - Adds `riverbank`, `stream_end`, `dam`, `weir`, `waterfall`, and `pressurised`
   to the list of waterway features
+- Populates `nds` and `members` for deleted elements from the previous version
 
 ### Fixed
 

--- a/src/main/scala/vectorpipe/internal/package.scala
+++ b/src/main/scala/vectorpipe/internal/package.scala
@@ -142,7 +142,8 @@ package object internal {
           when(!'visible and (lag('tags, 1) over idByVersion).isNotNull,
             lag('tags, 1) over idByVersion)
             .otherwise('tags) as 'tags,
-          $"nds.ref" as 'nds,
+          when(!'visible, lag($"nds.ref", 1) over idByVersion)
+            .otherwise($"nds.ref") as 'nds,
           'changeset,
           'timestamp,
           (lead('timestamp, 1) over idByVersion) as 'validUntil,
@@ -190,7 +191,8 @@ package object internal {
           when(!'visible and (lag('tags, 1) over idByUpdated).isNotNull,
             lag('tags, 1) over idByUpdated)
             .otherwise('tags) as 'tags,
-          'members,
+          when(!'visible, lag('members, 1) over idByUpdated)
+            .otherwise('members) as 'members,
           'changeset,
           'timestamp,
           (lead('timestamp, 1) over idByUpdated) as 'validUntil,


### PR DESCRIPTION
# Overview

Not only are coordinates and tags dropped from elements that have been deleted (i.e. changed to `visible = false`), `nds` and `members` are also dropped. This populates them using the version immediately prior to the deletion, which allows deletes to be better tracked in various circumstances.

## Checklist

- [x] Add entry to CHANGELOG.md 