### PR TITLE
Simplify by removing Row Encoders

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ language: scala
 scala:
   - 2.11.12
 
+jdk: openjdk8
+
 sbt_args: -J-Xmx6g
 
 sudo: false

--- a/src/main/scala/vectorpipe/internal/package.scala
+++ b/src/main/scala/vectorpipe/internal/package.scala
@@ -2,17 +2,14 @@ package vectorpipe
 
 import java.sql.Timestamp
 
-import org.locationtech.jts.{geom => jts}
 import geotrellis.vector._
 import org.apache.log4j.Logger
 import org.apache.spark.sql._
-import org.apache.spark.sql.catalyst.encoders.RowEncoder
-import org.apache.spark.sql.catalyst.expressions.GenericRowWithSchema
 import org.apache.spark.sql.expressions.Window
 import org.apache.spark.sql.functions._
-import org.apache.spark.sql.jts.GeometryUDT
 import org.apache.spark.sql.types._
 import org.locationtech.geomesa.spark.jts._
+import org.locationtech.jts.{geom => jts}
 import vectorpipe.functions.asDouble
 import vectorpipe.functions.osm._
 import vectorpipe.relations.{MultiPolygons, Routes}
@@ -24,41 +21,6 @@ package object internal {
   val MultiPolygonRoles: Seq[String] = Set("", "outer", "inner").toSeq
 
   @transient lazy val logger: Logger = Logger.getLogger(getClass)
-
-  lazy val BareElementSchema = StructType(
-    StructField("changeset", LongType, nullable = false) ::
-      StructField("id", LongType, nullable = false) ::
-      StructField("version", IntegerType, nullable = false) ::
-      StructField("updated", TimestampType, nullable = false) ::
-      StructField("geom", GeometryUDT) ::
-      Nil)
-
-  lazy val BareElementEncoder: Encoder[Row] = RowEncoder(BareElementSchema)
-
-  lazy val TaggedVersionedElementSchema = StructType(
-    StructField("changeset", LongType, nullable = false) ::
-      StructField("id", LongType, nullable = false) ::
-      StructField("tags", MapType(StringType, StringType, valueContainsNull = false), nullable = false) ::
-      StructField("version", IntegerType, nullable = false) ::
-      StructField("minorVersion", IntegerType, nullable = false) ::
-      StructField("updated", TimestampType, nullable = false) ::
-      StructField("validUntil", TimestampType) ::
-      StructField("geom", GeometryUDT) ::
-      Nil)
-
-  lazy val TaggedVersionedElementEncoder: Encoder[Row] = RowEncoder(TaggedVersionedElementSchema)
-
-  lazy val VersionedElementSchema = StructType(
-    StructField("changeset", LongType, nullable = false) ::
-      StructField("id", LongType, nullable = false) ::
-      StructField("version", IntegerType, nullable = false) ::
-      StructField("minorVersion", IntegerType, nullable = false) ::
-      StructField("updated", TimestampType, nullable = false) ::
-      StructField("validUntil", TimestampType) ::
-      StructField("geom", GeometryUDT) ::
-      Nil)
-
-  lazy val VersionedElementEncoder: Encoder[Row] = RowEncoder(VersionedElementSchema)
 
   /**
     * Pre-process nodes.
@@ -299,8 +261,6 @@ package object internal {
       .join(nodes.select('id as 'ref, 'timestamp, 'validUntil, 'lat, 'lon), Seq("ref"), "left_outer")
       .where('timestamp <= 'updated and 'updated < coalesce('validUntil, current_timestamp))
 
-    implicit val encoder: Encoder[Row] = BareElementEncoder
-
     val wayGeoms = waysAndNodes
       .select('changeset, 'id, 'version, 'updated, 'isArea, 'idx, 'lat, 'lon)
       .groupByKey(row =>
@@ -325,7 +285,7 @@ package object internal {
               // 1 pair of coordinates provided
               case coords if coords.length == 1 =>
                 Some(GeomFactory.factory.createPoint(new jts.Coordinate(coords.head.head, coords.head.last)))
-              case coords => {
+              case coords =>
                 val coordinates = coords.map(xy => new jts.Coordinate(xy.head, xy.last)).toArray
                 val line = GeomFactory.factory.createLineString(coordinates)
 
@@ -333,14 +293,14 @@ package object internal {
                   Some(GeomFactory.factory.createPolygon(line.getCoordinateSequence))
                 else
                   Some(line)
-              }
             }
           val geometry = geom match {
             case Some(g) if g.isValid => g
             case _ => null
           }
-          new GenericRowWithSchema(Array(changeset, id, version, updated, geometry), BareElementSchema): Row
+          (changeset, id, version, updated, geometry)
       }
+      .toDF("changeset", "id", "version", "updated", "geom")
 
     @transient val idAndVersionByUpdated = Window.partitionBy('id, 'version).orderBy('updated)
     @transient val idByUpdated = Window.partitionBy('id).orderBy('updated)
@@ -487,8 +447,6 @@ package object internal {
       .drop('memberValidUntil)
       .drop('ref)
 
-    implicit val encoder: Encoder[Row] = VersionedElementEncoder
-
     val relationGeoms = members
         .groupByKey { row =>
           (row.getAs[Long]("changeset"), row.getAs[Long]("id"), row.getAs[Integer]("version"), row.getAs[Integer]
@@ -501,11 +459,11 @@ package object internal {
             val roles = members.map(_.getAs[String]("role"))
             val geoms = members.map(_.getAs[jts.Geometry]("geom"))
 
-            val wkb = MultiPolygons.build(id, version, updated, types, roles, geoms).orNull
+            val geom = MultiPolygons.build(id, version, updated, types, roles, geoms).orNull
 
-            new GenericRowWithSchema(Array(changeset, id, version, minorVersion, updated, validUntil, wkb),
-              VersionedElementSchema): Row
+            (changeset, id, version, minorVersion, updated, validUntil, geom)
         }
+        .toDF("changeset", "id", "version", "minorVersion", "updated", "validUntil", "geom")
 
     // Join metadata to avoid passing it through exploded shuffles
     relationGeoms
@@ -559,8 +517,6 @@ package object internal {
       .drop('memberValidUntil)
       .drop('ref)
 
-    implicit val encoder: Encoder[Row] = TaggedVersionedElementEncoder
-
     // leverage partitioning (avoids repeated (de-)serialization of merged coordinate arrays)
     val relationGeoms = members
       .groupByKey { row =>
@@ -577,20 +533,18 @@ package object internal {
           Routes.build(id, version, updated, types, roles, geoms) match {
             case Some(components) =>
               components.map {
-                case ("", wkb) =>
+                case ("", geom) =>
                   // no role
-                  new GenericRowWithSchema(Array(changeset, id, Map(), version, minorVersion, updated,
-                    validUntil, wkb), TaggedVersionedElementSchema): Row
-                case (role, wkb) =>
-                  new GenericRowWithSchema(Array(changeset, id, Map("role" -> role), version, minorVersion,
-                    updated, validUntil, wkb), TaggedVersionedElementSchema): Row
+                  (changeset, id, Map.empty[String, String], version, minorVersion, updated, validUntil, geom)
+                case (role, geom) =>
+                  (changeset, id, Map("role" -> role), version, minorVersion, updated, validUntil, geom)
               }
             case None =>
               // no geometry
-              Seq(new GenericRowWithSchema(Array(changeset, id, Map(), version, minorVersion, updated,
-                validUntil, null), TaggedVersionedElementSchema): Row)
+              Seq((changeset, id, Map.empty[String, String], version, minorVersion, updated, validUntil, null))
           }
       }
+      .toDF("changeset", "id", "tags", "version", "minorVersion", "updated", "validUntil", "geom")
 
     // Join metadata to avoid passing it through exploded shuffles
     relationGeoms


### PR DESCRIPTION
# Overview

Instantiating `Row`s with `GenericRowWithSchema` is awkward and requires defining a schema that should otherwise be implicitly determined. This replaces that pattern with one whereby a tuple is returned and converted into a `DataFrame` with appropriate column names.

`CHANGELOG` entry omitted due to this being an internals-only change.