### PR TITLE
Checkpoint intermediate levels to reduce re-calculation

### DIFF
--- a/src/main/scala/vectorpipe/VectorPipe.scala
+++ b/src/main/scala/vectorpipe/VectorPipe.scala
@@ -137,6 +137,7 @@ object VectorPipe {
       val simplify = udf { g: jts.Geometry => pipeline.simplify(g, level.layout) }
       val reduced = pipeline
         .reduce(working, level, keyColumn)
+        .localCheckpoint()
       val prepared = reduced
         .withColumn(geomColumn, simplify(col(geomColumn)))
       val vts = generateVectorTiles(prepared, level)


### PR DESCRIPTION
# Overview

With this change, runtime for `PipelineSpec` → "should generate multiple zoom levels" (which creates 2 intermediate levels) goes from ~70s to ~28s.

## Notes

`PipelineSpec` → "should generate multiple layers" will fail without #97.

/cc @echeipesh @jpolchlo 