### PR TITLE
Return Dataset[BinaryTile] so generated MVTs can be stored in a single output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for `nds` in augmented diff GeoJSON (matching
     [`osm-replication-streams@^0.7.0`](https://github.com/mojodna/osm-replication-streams/tree/v0.7.0)
     output)
+- `VectorPipe.apply()` now returns `Dataset[BinaryTile]` with `(zoom, x, y,
+    bytes)`, suitable for extracting tiles from
 
 ### Changed
 
@@ -24,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Adds `riverbank`, `stream_end`, `dam`, `weir`, `waterfall`, and `pressurised`
   to the list of waterway features
 - Populates `nds` and `members` for deleted elements from the previous version
+- `baseOutputURI` is now `Option[URI]`; if absent, MVTs won't be written
 
 ### Fixed
 

--- a/src/main/scala/vectorpipe/vectortile/Pipeline.scala
+++ b/src/main/scala/vectorpipe/vectortile/Pipeline.scala
@@ -1,5 +1,7 @@
 package vectorpipe.vectortile
 
+import java.net.URI
+
 import geotrellis.spark.SpatialKey
 import geotrellis.spark.tiling._
 import geotrellis.vector.{Feature, Geometry}
@@ -48,7 +50,7 @@ trait Pipeline {
   /**
    * The root URI for output.
    */
-  val baseOutputURI: java.net.URI
+  val baseOutputURI: Option[URI]
 
   /**
    * Name of the column containing the JTS geometry.

--- a/src/test/scala/vectorpipe/vectortile/LayerTestPipeline.scala
+++ b/src/test/scala/vectorpipe/vectortile/LayerTestPipeline.scala
@@ -1,15 +1,16 @@
 package vectorpipe.vectortile
 
+import java.net.URI
+
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.functions
 import org.apache.spark.sql.functions.when
 import org.locationtech.jts.{geom => jts}
-
 import vectorpipe._
 import vectorpipe.functions.osm._
 import vectorpipe.vectortile._
 
-case class LayerTestPipeline(geometryColumn: String, baseOutputURI: java.net.URI) extends Pipeline {
+case class LayerTestPipeline(geometryColumn: String, baseOutputURI: Option[URI]) extends Pipeline {
   val layerMultiplicity = LayerNamesInColumn("layers")
 
   override def select(wayGeoms: DataFrame, targetZoom: Int, keyColumn: String): DataFrame = {

--- a/src/test/scala/vectorpipe/vectortile/PipelineSpec.scala
+++ b/src/test/scala/vectorpipe/vectortile/PipelineSpec.scala
@@ -1,5 +1,7 @@
 package vectorpipe.vectortile
 
+import java.net.URI
+
 import org.apache.spark.sql.functions
 import org.apache.spark.sql.functions.{isnull, lit}
 import org.locationtech.geomesa.spark.jts._
@@ -26,17 +28,17 @@ class PipelineSpec extends FunSpec with TestEnvironment with Matchers {
     val wayGeoms = vp.reconstructWayGeometries(df, nodes).cache
 
     it("should generate a single zoom level") {
-      val pipeline = TestPipeline("geometry", new java.net.URI("file:///tmp/iom-tiles"), 16)
+      val pipeline = TestPipeline("geometry", Some(new URI("file:///tmp/iom-tiles")), 16)
       VectorPipe(nodeGeoms, pipeline, VectorPipe.Options.forZoom(8))
     }
 
     it("should generate multiple zoom levels") {
-      val pipeline = TestPipeline("geometry", new java.net.URI("file:///tmp/iom-tiles-pyramid"), 16)
+      val pipeline = TestPipeline("geometry", Some(new URI("file:///tmp/iom-tiles-pyramid")), 16)
       VectorPipe(nodeGeoms, pipeline, VectorPipe.Options.forZoomRange(6, 8))
     }
 
     it("should generate multiple layers") {
-      val pipeline = LayerTestPipeline("geom", new java.net.URI("file:///tmp/iom-layers"))
+      val pipeline = LayerTestPipeline("geom", Some(new URI("file:///tmp/iom-layers")))
       VectorPipe(wayGeoms, pipeline, VectorPipe.Options.forZoom(14))
     }
   }

--- a/src/test/scala/vectorpipe/vectortile/TestPipeline.scala
+++ b/src/test/scala/vectorpipe/vectortile/TestPipeline.scala
@@ -1,18 +1,18 @@
 package vectorpipe.vectortile
 
+import java.net.URI
+
 import geotrellis.raster.RasterExtent
 import geotrellis.spark.SpatialKey
 import geotrellis.spark.tiling._
 import geotrellis.vector._
 import geotrellis.vectortile._
-
 import org.apache.spark.sql.{DataFrame, Row}
 import org.apache.spark.sql.catalyst.expressions.GenericRowWithSchema
 import org.apache.spark.sql.functions
 import org.apache.spark.sql.functions.{array, col, explode, lit, sum}
 import org.apache.spark.sql.types._
 import org.locationtech.jts.{geom => jts}
-
 import vectorpipe._
 import vectorpipe.vectortile._
 
@@ -21,7 +21,7 @@ object Bin {
   def apply(tup: (Int, Int)): Bin = Bin(tup._1, tup._2)
 }
 
-case class TestPipeline(geometryColumn: String, baseOutputURI: java.net.URI, gridResolution: Int) extends Pipeline {
+case class TestPipeline(geometryColumn: String, baseOutputURI: Option[URI], gridResolution: Int) extends Pipeline {
   val weightedCentroid = new WeightedCentroid
 
   val layerMultiplicity = SingleLayer("points")


### PR DESCRIPTION
# Overview

This is in addition to (optionally) writing individual MVTs out. This will save on object management and time taken to `PUT` individual tiles.

The single output contained generated MVTs can be subsequently processed to extract specific tiles or to write to an alternate data sink (e.g. MBTiles (#51)).

## Checklist

- [x] Add entry to CHANGELOG.md 