### PR TITLE
Skip unnecessary reprojection

### DIFF
--- a/src/main/scala/vectorpipe/VectorPipe.scala
+++ b/src/main/scala/vectorpipe/VectorPipe.scala
@@ -59,7 +59,11 @@ object VectorPipe {
     val zls = ZoomedLayoutScheme(destCRS, options.tileResolution)
 
     // Reproject geometries if needed
-    val reprojected = input.withColumn(geomColumn, st_reprojectGeom(col(geomColumn), lit(srcCRS.toProj4String), lit(destCRS.toProj4String)))
+    val reprojected = if (srcCRS != destCRS) {
+      input.withColumn(geomColumn, st_reprojectGeom(col(geomColumn), lit(srcCRS.toProj4String), lit(destCRS.toProj4String)))
+    } else {
+      input
+    }
 
     // Prefilter data for first iteration and key geometries to initial layout
     val keyColumn = {


### PR DESCRIPTION
# Overview

Skip reprojection when source and target CRSes match.