### PR TITLE
Filter out uninteresting tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for `nds` in augmented diff GeoJSON (matching
     [`osm-replication-streams@^0.7.0`](https://github.com/mojodna/osm-replication-streams/tree/v0.7.0)
     output)
+- "Uninteresting" tags are dropped when processing OSM inputs; this will result
+    in fewer point features being generated (as those nodes previously had tags
+    applied).
 
 ### Changed
 

--- a/src/main/scala/vectorpipe/functions/osm/package.scala
+++ b/src/main/scala/vectorpipe/functions/osm/package.scala
@@ -309,8 +309,6 @@ package object osm {
     "created_by",
     "source",
     "comment",
-    "fixme",
-    "note",
     "_ID",
     "CLC",
     "odbl",
@@ -336,7 +334,6 @@ package object osm {
   val UninterestingPrefixes: Set[String] = Set(
     "CLC",
     "tiger",
-    "source",
     "sby",
     "navibot",
     "nps",

--- a/src/main/scala/vectorpipe/functions/osm/package.scala
+++ b/src/main/scala/vectorpipe/functions/osm/package.scala
@@ -328,7 +328,38 @@ package object osm {
     "1",
     "_description_",
     "ccpr",
-    "dfg"
+    "dfg",
+    // https://github.com/gravitystorm/openstreetmap-carto/blob/master/openstreetmap-carto.lua#L51
+    "source_ref",
+    "ref:UrbIS",
+    "accuracy:meters",
+    "sub_sea:type",
+    "waterway:type",
+    "statscan:rbuid",
+    "ref:ruian:addr",
+    "ref:ruian",
+    "building:ruian:type",
+    "dibavod:id",
+    "uir_adr:ADRESA_KOD",
+    "gst:feat_id",
+    "maaamet:ETAK",
+    "ref:FR:FANTOIR",
+    "3dshapes:ggmodelk",
+    "AND_nosr_r",
+    "OPPDATERIN",
+    "addr:city:simc",
+    "addr:street:sym_ul",
+    "building:usage:pl",
+    "building:use:pl",
+    "teryt:simc",
+    "raba:id",
+    "dcgis:gis_id",
+    "nycdoitt:bin",
+    "chicago:building_id",
+    "lojic:bgnum",
+    "massgis:way_id",
+    "OBJTYPE",
+    "SK53_bulk:load"
   ).map(_.toLowerCase())
 
   val SemiInterestingTags: Set[String] = Set("source").map(_.toLowerCase())
@@ -340,7 +371,24 @@ package object osm {
     "navibot",
     "nps",
     "hoot",
-    "error"
+    "error",
+    "project",
+    // https://github.com/gravitystorm/openstreetmap-carto/blob/master/openstreetmap-carto.lua#L51
+    "geobase",
+    "canvec",
+    "osak",
+    "kms",
+    "ngbe",
+    "it:fvg",
+    "KSJ2",
+    "yh",
+    "LINZ2OSM",
+    "LINZ",
+    "WroclawGIS",
+    "naptap",
+    "gnis",
+    "NHD",
+    "mvdgis"
   ).map(_.toLowerCase())
 
   val SemiInterestingPrefixes: Set[String] = Set("source").map(_.toLowerCase())

--- a/src/main/scala/vectorpipe/functions/osm/package.scala
+++ b/src/main/scala/vectorpipe/functions/osm/package.scala
@@ -331,6 +331,8 @@ package object osm {
     "dfg"
   ).map(_.toLowerCase())
 
+  val SemiInterestingTags: Set[String] = Set("source").map(_.toLowerCase())
+
   val UninterestingPrefixes: Set[String] = Set(
     "CLC",
     "tiger",
@@ -340,6 +342,8 @@ package object osm {
     "hoot",
     "error"
   ).map(_.toLowerCase())
+
+  val SemiInterestingPrefixes: Set[String] = Set("source").map(_.toLowerCase())
 
   val UninterestingSingleTags: Set[String] = Set("colour").map(_.toLowerCase())
 
@@ -353,5 +357,14 @@ package object osm {
         !UninterestingPrefixes.exists(p => k.startsWith(s"$p:")) &&
         !k.contains("=") &&
         !k.contains(" ")
+    })
+
+  lazy val removeSemiInterestingTags: UserDefinedFunction = udf(_removeSemiInterestingTags)
+
+  private val _removeSemiInterestingTags = (tags: Map[String, String]) =>
+    tags.filterKeys(key => {
+      val k = key.toLowerCase
+      !SemiInterestingTags.contains(k) &&
+        !SemiInterestingPrefixes.exists(p => k.startsWith(s"$p:"))
     })
 }

--- a/src/main/scala/vectorpipe/internal/package.scala
+++ b/src/main/scala/vectorpipe/internal/package.scala
@@ -215,7 +215,7 @@ package object internal {
     import nodes.sparkSession.implicits._
 
     val ns = preprocessNodes(nodes)
-      .where(size(removeUninterestingTags('tags)) > 0)
+      .where(size(removeSemiInterestingTags('tags)) > 0)
 
     ns
       // fetch the last version of a node within a single changeset

--- a/src/main/scala/vectorpipe/internal/package.scala
+++ b/src/main/scala/vectorpipe/internal/package.scala
@@ -215,7 +215,7 @@ package object internal {
     import nodes.sparkSession.implicits._
 
     val ns = preprocessNodes(nodes)
-      .where(size('tags) > 0)
+      .where(size(removeUninterestingTags('tags)) > 0)
 
     ns
       // fetch the last version of a node within a single changeset

--- a/src/main/scala/vectorpipe/vectortile/export/package.scala
+++ b/src/main/scala/vectorpipe/vectortile/export/package.scala
@@ -3,14 +3,13 @@ package vectorpipe.vectortile
 import com.amazonaws.services.s3.model.CannedAccessControlList._
 import geotrellis.spark.SpatialKey
 import geotrellis.spark.io.hadoop._
-import geotrellis.spark.io.index.zcurve.Z2
 import geotrellis.spark.io.s3._
 import geotrellis.vectortile._
 import org.apache.spark.rdd.RDD
 
 import java.net.URI
 import java.io.ByteArrayOutputStream
-import java.util.zip.{GZIPOutputStream, ZipEntry, ZipOutputStream}
+import java.util.zip.GZIPOutputStream
 
 package object export {
   def saveVectorTiles(vectorTiles: RDD[(SpatialKey, VectorTile)], zoom: Int, uri: URI): Unit = {

--- a/src/test/scala/vectorpipe/functions/osm/FunctionSpec.scala
+++ b/src/test/scala/vectorpipe/functions/osm/FunctionSpec.scala
@@ -200,4 +200,25 @@ class FunctionSpec extends FunSpec with TestEnvironment with Matchers {
         .collect() should equal(Array(Row(Map("highway" -> "motorway")), Row(Map("building" -> "yes"))))
     }
   }
+
+  describe("removeSemiInterestingTags") {
+    it("drops semi-interesting tags") {
+      Seq(
+        Map("building" -> "yes", "source" -> "MassGIS")
+      )
+        .toDF("tags")
+        .withColumn("tags", removeSemiInterestingTags('tags))
+        .collect() should equal(Array(Row(Map("building" -> "yes"))))
+    }
+
+    it("drops semi-interesting prefixed tags") {
+      Seq(
+        Map("highway" -> "motorway", "source:geometry" -> "MassGIS")
+      )
+        .toDF("tags")
+        .withColumn("tags", removeSemiInterestingTags('tags))
+        .collect() should equal(Array(Row(Map("highway" -> "motorway"))))
+    }
+  }
+
 }

--- a/src/test/scala/vectorpipe/functions/osm/FunctionSpec.scala
+++ b/src/test/scala/vectorpipe/functions/osm/FunctionSpec.scala
@@ -1,5 +1,6 @@
 package vectorpipe.functions.osm
 
+import org.apache.spark.sql.Row
 import org.scalatest.{FunSpec, Matchers}
 import vectorpipe.TestEnvironment
 
@@ -156,6 +157,47 @@ class FunctionSpec extends FunSpec with TestEnvironment with Matchers {
         .toDF("tags", "value")
         .where(isWaterway('tags) =!= 'value)
         .count should equal(0)
+    }
+  }
+
+  describe("removeUninterestingTags") {
+    it("drops uninteresting tags") {
+      Seq(
+        Map("building" -> "yes", "created_by" -> "JOSM")
+      )
+        .toDF("tags")
+        .withColumn("tags", removeUninterestingTags('tags))
+        .collect() should equal(Array(Row(Map("building" -> "yes"))))
+    }
+
+    it("drops uninteresting single tags") {
+      Seq(
+        Map("building" -> "yes", "colour" -> "grey"),
+        Map("colour" -> "grey")
+      )
+        .toDF("tags")
+        .withColumn("tags", removeUninterestingTags('tags))
+        .collect() should equal(Array(Row(Map("building" -> "yes", "colour" -> "grey")), Row(Map.empty)))
+    }
+
+    it("drops uninteresting prefixed tags") {
+      Seq(
+        Map("highway" -> "motorway", "tiger:reviewed" -> "no"),
+        Map("building" -> "yes", "CLC:something" -> "something")
+      )
+        .toDF("tags")
+        .withColumn("tags", removeUninterestingTags('tags))
+        .collect() should equal(Array(Row(Map("highway" -> "motorway")), Row(Map("building" -> "yes"))))
+    }
+
+    it("drops tags with invalid keys") {
+      Seq(
+        Map("highway" -> "motorway", "k=v" -> "value"),
+        Map("building" -> "yes", "land use" -> "something")
+      )
+        .toDF("tags")
+        .withColumn("tags", removeUninterestingTags('tags))
+        .collect() should equal(Array(Row(Map("highway" -> "motorway")), Row(Map("building" -> "yes"))))
     }
   }
 }


### PR DESCRIPTION
# Overview

Uninteresting tags are those that have little-to-no rendering relevance and shouldn't be considered when promoting nodes to points. The tag (and prefix) list was generated by querying for the top 200 single-use tags (i.e. the only tag applied to an element). `fixme`, `note`, and `source` are omitted, as they can be useful for validation and tracking.

## Checklist

- [x] Add entry to CHANGELOG.md