### PR TITLE
Generate vector tiles as Datasets

### DIFF
--- a/src/main/scala/vectorpipe/vectortile/export/package.scala
+++ b/src/main/scala/vectorpipe/vectortile/export/package.scala
@@ -7,20 +7,26 @@ import geotrellis.spark.io.index.zcurve.Z2
 import geotrellis.spark.io.s3._
 import geotrellis.vectortile._
 import org.apache.spark.rdd.RDD
-
 import java.net.URI
 import java.io.ByteArrayOutputStream
 import java.util.zip.{GZIPOutputStream, ZipEntry, ZipOutputStream}
 
+import org.apache.spark.sql.Dataset
+import vectorpipe.Tile
+
 package object export {
-  def saveVectorTiles(vectorTiles: RDD[(SpatialKey, VectorTile)], zoom: Int, uri: URI): Unit = {
+  def saveVectorTiles(vectorTiles: Dataset[Tile], zoom: Int, uri: URI): Unit = {
+    import vectorTiles.sparkSession.implicits._
+
+    val vts = vectorTiles.map(x => (x.sk, x.tile)).rdd
+
     uri.getScheme match {
       case "s3" =>
         val path = uri.getPath
         val prefix = path.stripPrefix("/").stripSuffix("/")
-        saveToS3(vectorTiles, zoom, uri.getAuthority, prefix)
+        saveToS3(vts, zoom, uri.getAuthority, prefix)
       case _ =>
-        saveHadoop(vectorTiles, zoom, uri)
+        saveHadoop(vts, zoom, uri)
     }
   }
 

--- a/src/main/scala/vectorpipe/vectortile/package.scala
+++ b/src/main/scala/vectorpipe/vectortile/package.scala
@@ -119,21 +119,6 @@ package object vectortile {
   }
 
   def buildVectorTile[G <: Geometry](
-    features: Iterable[VectorTileFeature[G]],
-    layerName: String,
-    ex: Extent,
-    tileWidth: Int,
-    sorted: Boolean
-  ): VectorTile = {
-    val layer =
-      if (sorted)
-        buildSortedLayer(features, layerName, ex, tileWidth)
-      else
-        buildLayer(features, layerName, ex, tileWidth)
-    VectorTile(Map(layerName -> layer), ex)
-  }
-
-  def buildVectorTile[G <: Geometry](
     layerFeatures: Map[String, Iterable[VectorTileFeature[G]]],
     ex: Extent,
     tileWidth: Int,


### PR DESCRIPTION
# Overview

This pulls the `VectorTile` generation out of RDD-land by defining some case classes (and some ugly `Value` conversion) that Spark can serialize automatically.

## Notes

When I benchmarked this (lightly), runtime was similar to the RDD-based approach but Spark _was_ able to show me a concrete plan.

There are similarities in approach and goal to bits of #93.