### PR TITLE
Initialize JTS internally

### DIFF
--- a/src/main/scala/vectorpipe/OSM.scala
+++ b/src/main/scala/vectorpipe/OSM.scala
@@ -29,7 +29,10 @@ object OSM {
     * @return DataFrame containing geometries.
     */
   def toGeometry(elements: DataFrame): DataFrame = {
-    import elements.sparkSession.implicits._
+    val spark = elements.sparkSession
+    import spark.implicits._
+    spark.withJTS
+
     val st_pointToGeom = org.apache.spark.sql.functions.udf { pt: jts.Point => pt.asInstanceOf[jts.Geometry] }
 
     val nodes = preprocessNodes(elements)

--- a/src/main/scala/vectorpipe/internal/package.scala
+++ b/src/main/scala/vectorpipe/internal/package.scala
@@ -205,7 +205,9 @@ package object internal {
     * @return Nodes as Point geometries
     */
   def constructPointGeometries(nodes: DataFrame): DataFrame = {
-    import nodes.sparkSession.implicits._
+    val spark = nodes.sparkSession
+    import spark.implicits._
+    spark.withJTS
 
     val ns = preprocessNodes(nodes)
       .where(size('tags) > 0)

--- a/src/test/scala/vectorpipe/ProcessOSMTest.scala
+++ b/src/test/scala/vectorpipe/ProcessOSMTest.scala
@@ -1,13 +1,10 @@
 package vectorpipe
 
-import org.locationtech.geomesa.spark.jts._
 import org.scalatest._
 import vectorpipe.{internal => ProcessOSM}
 import vectorpipe.functions.osm.ensureCompressedMembers
 
 class ProcessOSMTest extends FunSpec with TestEnvironment with Matchers {
-  ss.withJTS
-
   val orcFile = getClass.getResource("/isle-of-man-latest.osm.orc").getPath
 
   val elements = ss.read.orc(orcFile)


### PR DESCRIPTION
# Overview

Initialize JTS before using geometry functions. This prevents callers from needing to be aware of the `spark.withJTS` incantation.