### PR TITLE
Warn about unused imports

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -28,7 +28,8 @@ lazy val commonSettings = Seq(
     "-feature",
     "-Ywarn-dead-code",
     "-Ypartial-unification",
-    "-Ypatmat-exhaust-depth", "100"
+    "-Ypatmat-exhaust-depth", "100",
+    "-Ywarn-unused-import"
   ),
 
   scalacOptions in (Compile, doc) += "-groups",


### PR DESCRIPTION
# Overview

When developing outside of an IDE, unused imports are difficult to track without warnings from the compiler. This enables said warnings.