### PR TITLE
Fallback to the current sequence as a starting point

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Streaming sources now fallback to the current remote sequence if no database
+  checkpoint or option can be found
+
 ### Fixed
 
 ## [1.1.0] - 2019-09-26

--- a/src/main/scala/vectorpipe/sources/ReplicationStreamMicroBatchReader.scala
+++ b/src/main/scala/vectorpipe/sources/ReplicationStreamMicroBatchReader.scala
@@ -43,7 +43,8 @@ abstract class ReplicationStreamMicroBatchReader[T <: Product: TypeTag](options:
     val startSequenceOption = options.get(Source.StartSequence).asScala.map(_.toInt)
     val start = databaseUri.flatMap { uri =>
       recoverSequence(uri, procName)
-    } orElse startSequenceOption
+    } orElse startSequenceOption.orElse(getCurrentSequence)
+
     logInfo(s"Starting with sequence: $start")
     start
   }


### PR DESCRIPTION
# Overview

Streaming source sequence resolution rules are now:

1) `checkpoints` table (based on `Source.ProcessName`)
2) `Source.StartSequence` option
3) current remote sequence number

## Checklist

- [x] Add entry to CHANGELOG.md 