### PR TITLE
Upgrade to GT3.0 codebase

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ clipping/*
 osmosis/*
 .idea
 target
+.metals
 \#*
 .\#*
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+This is the first release to depend on GeoTrellis 3.0.
+
 ### Added
 
 ### Changed
@@ -23,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `useCaching` option to VectorPipe.Options allows for persisting to disk.
   Helps avoid repeated computations.
 - Functions for converting sequence numbers to timestamps and back for both
-  changeset replications and augmented diff replications.  See `ChangesetSource`
+  changeset replications and augmented diff replications. See `ChangesetSource`
   and `AugmentedDiffSource` in `vectorpipe.sources`.
 
 ### Changed
@@ -39,11 +41,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - RELEASING.md - Instructions for releasing new versions of this project
 - Support for semicolon-delimited tag values in UDFs, e.g. `shop=bakery;dairy`
 - Support for `nds` in augmented diff GeoJSON (matching
-    [`osm-replication-streams@^0.7.0`](https://github.com/mojodna/osm-replication-streams/tree/v0.7.0)
-    output)
+  [`osm-replication-streams@^0.7.0`](https://github.com/mojodna/osm-replication-streams/tree/v0.7.0)
+  output)
 - "Uninteresting" tags are dropped when processing OSM inputs; this will result
-    in fewer point features being generated (as those nodes previously had tags
-    applied).
+  in fewer point features being generated (as those nodes previously had tags
+  applied).
 
 ### Changed
 

--- a/build.sbt
+++ b/build.sbt
@@ -118,6 +118,19 @@ val vpExtraSettings = Seq(
     "com.amazonaws" % "aws-java-sdk-s3" % "1.11.518" % Provided
   ),
 
+  dependencyOverrides ++= {
+    val deps = Seq(
+      "com.fasterxml.jackson.core" % "jackson-core" % "2.6.7",
+      "com.fasterxml.jackson.core" % "jackson-databind" % "2.6.7",
+      "com.fasterxml.jackson.core" % "jackson-annotations" % "2.6.7"
+    )
+    CrossVersion.partialVersion(scalaVersion.value) match {
+      // if Scala 2.12+ is used
+      case Some((2, scalaMajor)) if scalaMajor >= 12 => deps
+      case _ => deps :+ "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.6.7"
+    }
+  },
+
   test in assembly := {},
   assemblyJarName in assembly := "vectorpipe.jar",
 

--- a/build.sbt
+++ b/build.sbt
@@ -98,6 +98,7 @@ val vpExtraSettings = Seq(
     sparkSql % Provided,
     sparkJts,
     gtS3 exclude ("com.google.protobuf", "protobuf-java") exclude ("com.amazonaws", "aws-java-sdk-s3"),
+    gtS3Spark exclude ("com.google.protobuf", "protobuf-java") exclude ("com.amazonaws", "aws-java-sdk-s3"),
     gtSpark exclude ("com.google.protobuf", "protobuf-java"),
     gtVectorTile exclude ("com.google.protobuf", "protobuf-java"),
     decline,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -11,6 +11,8 @@ object Dependencies {
   val gtGeomesa      = "org.locationtech.geotrellis" %% "geotrellis-geomesa"          % Version.geotrellis
   val gtGeotools     = "org.locationtech.geotrellis" %% "geotrellis-geotools"         % Version.geotrellis
   val gtS3           = "org.locationtech.geotrellis" %% "geotrellis-s3"               % Version.geotrellis
+
+  val gtS3Spark      = "org.locationtech.geotrellis" %% "geotrellis-s3-spark"         % Version.geotrellis
   val gtSpark        = "org.locationtech.geotrellis" %% "geotrellis-spark"            % Version.geotrellis
   val gtSparkTestKit = "org.locationtech.geotrellis" %% "geotrellis-spark-testkit"    % Version.geotrellis % "test"
   val gtVector       = "org.locationtech.geotrellis" %% "geotrellis-vector"           % Version.geotrellis

--- a/project/Version.scala
+++ b/project/Version.scala
@@ -1,6 +1,6 @@
 object Version {
   val awscala = "0.8.1"
-  val vectorpipe = "1.2.0-SNAPSHOT"
+  val vectorpipe = "2.0.0-SNAPSHOT"
   val scala = "2.11.12"
   val geotrellis = "3.0.0-SNAPSHOT"
   val geomesa = "2.2.1"

--- a/project/Version.scala
+++ b/project/Version.scala
@@ -2,7 +2,7 @@ object Version {
   val awscala = "0.8.1"
   val vectorpipe = "1.2.0-SNAPSHOT"
   val scala = "2.11.12"
-  val geotrellis = "2.2.0"
+  val geotrellis = "3.0.0-SNAPSHOT"
   val geomesa = "2.2.1"
   val decline = "0.6.1"
   val cats = "1.6.0"

--- a/src/main/scala/vectorpipe/OSM.scala
+++ b/src/main/scala/vectorpipe/OSM.scala
@@ -2,9 +2,9 @@ package vectorpipe
 
 import java.sql.Timestamp
 
-import org.locationtech.jts.{geom => jts}
 import org.apache.spark.sql._
 import org.apache.spark.sql.functions._
+import geotrellis.vector._
 import vectorpipe.functions.osm.removeUninterestingTags
 import vectorpipe.internal._
 
@@ -22,7 +22,7 @@ object OSM {
   def toGeometry(input: DataFrame): DataFrame = {
     import input.sparkSession.implicits._
 
-    val st_pointToGeom = org.apache.spark.sql.functions.udf { pt: jts.Point => pt.asInstanceOf[jts.Geometry] }
+    val st_pointToGeom = org.apache.spark.sql.functions.udf { pt: Point => pt.asInstanceOf[Geometry] }
 
     val elements = input
       .withColumn("tags", removeUninterestingTags('tags))

--- a/src/main/scala/vectorpipe/VectorPipe.scala
+++ b/src/main/scala/vectorpipe/VectorPipe.scala
@@ -14,7 +14,6 @@ import org.apache.spark.sql.catalyst.expressions.GenericRowWithSchema
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types.StringType
 import org.apache.spark.storage.StorageLevel
-import org.locationtech.jts.{geom => jts}
 
 object VectorPipe {
 
@@ -53,7 +52,7 @@ object VectorPipe {
   def apply(input: DataFrame, pipeline: vectortile.Pipeline, options: Options): Unit = {
     val geomColumn = pipeline.geometryColumn
     assert(input.columns.contains(geomColumn) &&
-           input.schema(geomColumn).dataType.isInstanceOf[org.apache.spark.sql.jts.AbstractGeometryUDT[jts.Geometry]],
+           input.schema(geomColumn).dataType.isInstanceOf[org.apache.spark.sql.jts.AbstractGeometryUDT[Geometry]],
            s"Input DataFrame must contain a column `${geomColumn}` of JTS Geometry")
 
     val srcCRS = options.srcCRS
@@ -84,7 +83,7 @@ object VectorPipe {
 
     def generateVectorTiles[G <: Geometry](df: DataFrame, level: LayoutLevel): RDD[(SpatialKey, VectorTile)] = {
       val zoom = level.zoom
-      val clip = udf { (g: jts.Geometry, key: GenericRowWithSchema) =>
+      val clip = udf { (g: Geometry, key: GenericRowWithSchema) =>
         val k = getSpatialKey(key)
         pipeline.clip(g, k, level)
       }
@@ -142,7 +141,7 @@ object VectorPipe {
         } else {
           df
         }
-      val simplify = udf { g: jts.Geometry => pipeline.simplify(g, level.layout) }
+      val simplify = udf { g: Geometry => pipeline.simplify(g, level.layout) }
       val reduced = pipeline
         .reduce(working, level, keyColumn)
       val persisted = if (options.useCaching) reduced.persist(StorageLevel.DISK_ONLY) else reduced

--- a/src/main/scala/vectorpipe/VectorPipe.scala
+++ b/src/main/scala/vectorpipe/VectorPipe.scala
@@ -4,10 +4,10 @@ import vectorpipe.vectortile._
 import vectorpipe.vectortile.export._
 
 import geotrellis.proj4.{CRS, LatLng, WebMercator}
-import geotrellis.spark.SpatialKey
-import geotrellis.spark.tiling.{ZoomedLayoutScheme, LayoutLevel}
-import geotrellis.vector.Geometry
+import geotrellis.layer._
+import geotrellis.vector._
 import geotrellis.vectortile._
+
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.expressions.GenericRowWithSchema

--- a/src/main/scala/vectorpipe/model/AugmentedDiff.scala
+++ b/src/main/scala/vectorpipe/model/AugmentedDiff.scala
@@ -2,15 +2,13 @@ package vectorpipe.model
 
 import java.sql.Timestamp
 
-import org.locationtech.jts.{geom => jts}
-
 import geotrellis.vector._
 
 case class AugmentedDiff(sequence: Int,
                          `type`: Byte,
                          id: Long,
-                         prevGeom: Option[jts.Geometry],
-                         geom: jts.Geometry,
+                         prevGeom: Option[Geometry],
+                         geom: Geometry,
                          prevTags: Option[Map[String, String]],
                          tags: Map[String, String],
                          prevNds: Option[Seq[Long]],
@@ -31,8 +29,8 @@ case class AugmentedDiff(sequence: Int,
 
 object AugmentedDiff {
   def apply(sequence: Int,
-            prev: Option[Feature[jts.Geometry, ElementWithSequence]],
-            curr: Feature[jts.Geometry, ElementWithSequence]): AugmentedDiff = {
+            prev: Option[Feature[Geometry, ElementWithSequence]],
+            curr: Feature[Geometry, ElementWithSequence]): AugmentedDiff = {
     val `type` = Member.typeFromString(curr.data.`type`)
     val minorVersion = prev.map(_.data.version).getOrElse(Int.MinValue) == curr.data.version
 

--- a/src/main/scala/vectorpipe/model/AugmentedDiff.scala
+++ b/src/main/scala/vectorpipe/model/AugmentedDiff.scala
@@ -3,7 +3,8 @@ package vectorpipe.model
 import java.sql.Timestamp
 
 import org.locationtech.jts.{geom => jts}
-import geotrellis.vector.{Feature, Geometry => GTGeometry}
+
+import geotrellis.vector._
 
 case class AugmentedDiff(sequence: Int,
                          `type`: Byte,
@@ -30,8 +31,8 @@ case class AugmentedDiff(sequence: Int,
 
 object AugmentedDiff {
   def apply(sequence: Int,
-            prev: Option[Feature[GTGeometry, ElementWithSequence]],
-            curr: Feature[GTGeometry, ElementWithSequence]): AugmentedDiff = {
+            prev: Option[Feature[jts.Geometry, ElementWithSequence]],
+            curr: Feature[jts.Geometry, ElementWithSequence]): AugmentedDiff = {
     val `type` = Member.typeFromString(curr.data.`type`)
     val minorVersion = prev.map(_.data.version).getOrElse(Int.MinValue) == curr.data.version
 
@@ -39,8 +40,8 @@ object AugmentedDiff {
       sequence,
       `type`,
       curr.data.id,
-      prev.map(_.geom.jtsGeom),
-      curr.geom.jtsGeom,
+      prev.map(_.geom),
+      curr.geom,
       prev.map(_.data.tags),
       curr.data.tags,
       prev.map(_.data.nds),

--- a/src/main/scala/vectorpipe/relations/Routes.scala
+++ b/src/main/scala/vectorpipe/relations/Routes.scala
@@ -1,7 +1,8 @@
 package vectorpipe.relations
 import java.sql.Timestamp
 
-import org.locationtech.jts.geom.{Geometry, TopologyException}
+import geotrellis.vector._
+import org.locationtech.jts.geom.TopologyException
 import org.apache.log4j.Logger
 import vectorpipe.internal.WayType
 

--- a/src/main/scala/vectorpipe/relations/utils/package.scala
+++ b/src/main/scala/vectorpipe/relations/utils/package.scala
@@ -1,4 +1,5 @@
 package vectorpipe.relations
+
 import org.locationtech.jts.geom.CoordinateSequence
 
 package object utils {

--- a/src/main/scala/vectorpipe/vectortile/Pipeline.scala
+++ b/src/main/scala/vectorpipe/vectortile/Pipeline.scala
@@ -1,10 +1,9 @@
 package vectorpipe.vectortile
 
-import geotrellis.vector.{Feature, Geometry}
 import geotrellis.layer._
+import geotrellis.vector._
 
 import org.apache.spark.sql.{DataFrame, Row}
-import org.locationtech.jts.{geom => jts}
 
 /**
  * The interface governing the transformation from processed OSM dataframes to
@@ -109,7 +108,7 @@ trait Pipeline {
    * is a simplifier using JTS's topology-preserving simplifier available in
    * [[vectorpipe.vectortile.Simplify]].
    */
-  def simplify(g: jts.Geometry, layout: LayoutDefinition): jts.Geometry = g
+  def simplify(g: Geometry, layout: LayoutDefinition): Geometry = g
 
   /**
    * Select geometries for display at a given zoom level.
@@ -138,7 +137,7 @@ trait Pipeline {
    *
    * Basic (non-no-op) clipping functions can be found in [[Clipping]].
    */
-  def clip(geom: jts.Geometry, key: SpatialKey, layoutLevel: LayoutLevel): jts.Geometry = geom
+  def clip(geom: Geometry, key: SpatialKey, layoutLevel: LayoutLevel): Geometry = geom
 
   /**
    * Convert table rows to output features.
@@ -148,5 +147,5 @@ trait Pipeline {
    * See [[geotrellis.vectortile.Value]] for details.
    */
   def pack(row: Row, zoom: Int): VectorTileFeature[Geometry] =
-    Feature(row.getAs[jts.Geometry](geometryColumn), Map.empty)
+    Feature(row.getAs[Geometry](geometryColumn), Map.empty)
 }

--- a/src/main/scala/vectorpipe/vectortile/Pipeline.scala
+++ b/src/main/scala/vectorpipe/vectortile/Pipeline.scala
@@ -1,8 +1,8 @@
 package vectorpipe.vectortile
 
-import geotrellis.spark.SpatialKey
-import geotrellis.spark.tiling._
 import geotrellis.vector.{Feature, Geometry}
+import geotrellis.layer._
+
 import org.apache.spark.sql.{DataFrame, Row}
 import org.locationtech.jts.{geom => jts}
 
@@ -148,5 +148,5 @@ trait Pipeline {
    * See [[geotrellis.vectortile.Value]] for details.
    */
   def pack(row: Row, zoom: Int): VectorTileFeature[Geometry] =
-    Feature(Geometry(row.getAs[jts.Geometry](geometryColumn)), Map.empty)
+    Feature(row.getAs[jts.Geometry](geometryColumn), Map.empty)
 }

--- a/src/main/scala/vectorpipe/vectortile/Simplify.scala
+++ b/src/main/scala/vectorpipe/vectortile/Simplify.scala
@@ -1,7 +1,7 @@
 package vectorpipe.vectortile
 
-import geotrellis.spark.tiling.LayoutDefinition
-import org.locationtech.jts.{geom => jts}
+import geotrellis.vector._
+import geotrellis.layer._
 import org.locationtech.jts.simplify.TopologyPreservingSimplifier
 
 object Simplify {
@@ -13,7 +13,7 @@ object Simplify {
    * JTS documentation.  Faster simplifiers with fewer guarantees are available
    * there as well.
    */
-  def withJTS(g: jts.Geometry, ld: LayoutDefinition): jts.Geometry = {
+  def withJTS(g: Geometry, ld: LayoutDefinition): Geometry = {
     TopologyPreservingSimplifier.simplify(g, ld.cellSize.resolution)
   }
 

--- a/src/main/scala/vectorpipe/vectortile/export/package.scala
+++ b/src/main/scala/vectorpipe/vectortile/export/package.scala
@@ -1,11 +1,12 @@
 package vectorpipe.vectortile
 
-import com.amazonaws.services.s3.model.CannedAccessControlList._
-import geotrellis.spark.SpatialKey
-import geotrellis.spark.io.hadoop._
-import geotrellis.spark.io.s3._
+import geotrellis.layer.SpatialKey
+import geotrellis.spark.store.hadoop._
+import geotrellis.spark.store.s3._
 import geotrellis.vectortile._
 import org.apache.spark.rdd.RDD
+
+import software.amazon.awssdk.services.s3.model.ObjectCannedACL
 
 import java.net.URI
 import java.io.ByteArrayOutputStream
@@ -43,14 +44,12 @@ package object export {
       }
       .saveToS3(
         { sk: SpatialKey => s"s3://${bucket}/${prefix}/${zoom}/${sk.col}/${sk.row}.mvt" },
-        putObjectModifier = { o =>
-          val md = o.getMetadata
-
-          md.setContentEncoding("gzip")
-
-          o
-            .withMetadata(md)
-            .withCannedAcl(PublicRead)
+        putObjectModifier = { request =>
+          request
+            .toBuilder()
+            .contentEncoding("gzip")
+            .acl(ObjectCannedACL.PUBLIC_READ)
+            .build()
         })
   }
 

--- a/src/test/scala/vectorpipe/MultiPolygonRelationReconstructionSpec.scala
+++ b/src/test/scala/vectorpipe/MultiPolygonRelationReconstructionSpec.scala
@@ -2,7 +2,7 @@ package vectorpipe
 
 import java.sql.Timestamp
 
-import geotrellis.spark.io.kryo.KryoRegistrator
+import geotrellis.spark.store.kryo.KryoRegistrator
 import org.apache.spark.SparkConf
 import org.apache.spark.serializer.KryoSerializer
 import org.apache.spark.sql._

--- a/src/test/scala/vectorpipe/sources/AugmentedDiffSourceTest.scala
+++ b/src/test/scala/vectorpipe/sources/AugmentedDiffSourceTest.scala
@@ -1,6 +1,5 @@
 package vectorpipe.sources
 
-import org.apache.spark.sql.Row
 import org.scalatest.{FunSpec, Matchers}
 import vectorpipe.TestEnvironment
 

--- a/src/test/scala/vectorpipe/vectortile/LayerTestPipeline.scala
+++ b/src/test/scala/vectorpipe/vectortile/LayerTestPipeline.scala
@@ -1,13 +1,12 @@
 package vectorpipe.vectortile
 
+import geotrellis.vector._
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.functions
 import org.apache.spark.sql.functions.when
-import org.locationtech.jts.{geom => jts}
 
 import vectorpipe._
 import vectorpipe.functions.osm._
-import vectorpipe.vectortile._
 
 case class LayerTestPipeline(geometryColumn: String, baseOutputURI: java.net.URI) extends Pipeline {
   val layerMultiplicity = LayerNamesInColumn("layers")
@@ -20,6 +19,6 @@ case class LayerTestPipeline(geometryColumn: String, baseOutputURI: java.net.URI
       .where(functions.not(functions.isnull('layers)))
   }
 
-  override def clip(geom: jts.Geometry, key: geotrellis.layer.SpatialKey, layoutLevel: geotrellis.layer.LayoutLevel): jts.Geometry =
+  override def clip(geom: Geometry, key: geotrellis.layer.SpatialKey, layoutLevel: geotrellis.layer.LayoutLevel): Geometry =
     Clipping.byLayoutCell(geom, key, layoutLevel)
 }

--- a/src/test/scala/vectorpipe/vectortile/LayerTestPipeline.scala
+++ b/src/test/scala/vectorpipe/vectortile/LayerTestPipeline.scala
@@ -20,6 +20,6 @@ case class LayerTestPipeline(geometryColumn: String, baseOutputURI: java.net.URI
       .where(functions.not(functions.isnull('layers)))
   }
 
-  override def clip(geom: jts.Geometry, key: geotrellis.spark.SpatialKey, layoutLevel: geotrellis.spark.tiling.LayoutLevel): jts.Geometry =
+  override def clip(geom: jts.Geometry, key: geotrellis.layer.SpatialKey, layoutLevel: geotrellis.layer.LayoutLevel): jts.Geometry =
     Clipping.byLayoutCell(geom, key, layoutLevel)
 }

--- a/src/test/scala/vectorpipe/vectortile/TestPipeline.scala
+++ b/src/test/scala/vectorpipe/vectortile/TestPipeline.scala
@@ -1,8 +1,7 @@
 package vectorpipe.vectortile
 
 import geotrellis.raster.RasterExtent
-import geotrellis.spark.SpatialKey
-import geotrellis.spark.tiling._
+import geotrellis.layer._
 import geotrellis.vector._
 import geotrellis.vectortile._
 
@@ -10,11 +9,9 @@ import org.apache.spark.sql.{DataFrame, Row}
 import org.apache.spark.sql.catalyst.expressions.GenericRowWithSchema
 import org.apache.spark.sql.functions
 import org.apache.spark.sql.functions.{array, col, explode, lit, sum}
-import org.apache.spark.sql.types._
 import org.locationtech.jts.{geom => jts}
 
 import vectorpipe._
-import vectorpipe.vectortile._
 
 case class Bin(x: Int, y: Int)
 object Bin {
@@ -49,7 +46,7 @@ case class TestPipeline(geometryColumn: String, baseOutputURI: java.net.URI, gri
   }
 
   override def pack(row: Row, zoom: Int): VectorTileFeature[Point] = {
-    val g = new Point(row.getAs[jts.Point](geometryColumn))
+    val g = row.getAs[jts.Point](geometryColumn)
     val weight = row.getAs[Long]("weight")
 
     Feature(g, Map( "weight" -> VInt64(weight) ))

--- a/src/test/scala/vectorpipe/vectortile/TestPipeline.scala
+++ b/src/test/scala/vectorpipe/vectortile/TestPipeline.scala
@@ -8,8 +8,7 @@ import geotrellis.vectortile._
 import org.apache.spark.sql.{DataFrame, Row}
 import org.apache.spark.sql.catalyst.expressions.GenericRowWithSchema
 import org.apache.spark.sql.functions
-import org.apache.spark.sql.functions.{array, col, explode, lit, sum}
-import org.locationtech.jts.{geom => jts}
+import org.apache.spark.sql.functions.{array, col, explode, sum}
 
 import vectorpipe._
 
@@ -27,15 +26,15 @@ case class TestPipeline(geometryColumn: String, baseOutputURI: java.net.URI, gri
     import input.sparkSession.implicits._
 
     val layout = layoutLevel.layout
-    val binOfTile = functions.udf { (g: jts.Geometry, key: GenericRowWithSchema) =>
-      val pt = g.asInstanceOf[jts.Point]
+    val binOfTile = functions.udf { (g: Geometry, key: GenericRowWithSchema) =>
+      val pt = g.asInstanceOf[Point]
       val k = getSpatialKey(key)
       val re = RasterExtent(layout.mapTransform.keyToExtent(k), gridResolution, gridResolution)
       val c = pt.getCoordinate
       Bin(re.mapToGrid(c.x, c.y))
     }
 
-    val st_geomToPoint = functions.udf { g: jts.Geometry => g.asInstanceOf[jts.Point] }
+    val st_geomToPoint = functions.udf { g: Geometry => g.asInstanceOf[Point] }
 
     input.withColumn(keyColumn, explode(col(keyColumn)))
       .withColumn("bin", binOfTile(col(geometryColumn), col(keyColumn)))
@@ -46,7 +45,7 @@ case class TestPipeline(geometryColumn: String, baseOutputURI: java.net.URI, gri
   }
 
   override def pack(row: Row, zoom: Int): VectorTileFeature[Point] = {
-    val g = row.getAs[jts.Point](geometryColumn)
+    val g = row.getAs[Point](geometryColumn)
     val weight = row.getAs[Long]("weight")
 
     Feature(g, Map( "weight" -> VInt64(weight) ))

--- a/src/test/scala/vectorpipe/vectortile/WeightedCentroid.scala
+++ b/src/test/scala/vectorpipe/vectortile/WeightedCentroid.scala
@@ -1,11 +1,12 @@
 package vectorpipe.vectortile
 
-import org.apache.spark.sql.{DataFrame, Row}
-import org.apache.spark.sql.functions._
+import geotrellis.vector._
+import org.apache.spark.sql.Row
 import org.apache.spark.sql.expressions.MutableAggregationBuffer
 import org.apache.spark.sql.expressions.UserDefinedAggregateFunction
 import org.apache.spark.sql.jts.PointUDT
 import org.apache.spark.sql.types._
+import org.locationtech.jts.geom.{Coordinate, GeometryFactory}
 
 class WeightedCentroid extends UserDefinedAggregateFunction {
 
@@ -33,7 +34,7 @@ class WeightedCentroid extends UserDefinedAggregateFunction {
 
   // Combine a new input with an existing buffer
   override def update(buffer: MutableAggregationBuffer, input: Row): Unit = {
-    val c = input.getAs[org.locationtech.jts.geom.Point](0).getCoordinate
+    val c = input.getAs[Point](0).getCoordinate
     val wt = input.getAs[Double](1)
     buffer(0) = buffer.getAs[Double](0) + c.x * wt
     buffer(1) = buffer.getAs[Double](1) + c.y * wt
@@ -52,6 +53,6 @@ class WeightedCentroid extends UserDefinedAggregateFunction {
     val wx = buffer.getDouble(0)
     val wy = buffer.getDouble(1)
     val wt = buffer.getDouble(2)
-    (new org.locationtech.jts.geom.GeometryFactory).createPoint(new org.locationtech.jts.geom.Coordinate(wx/wt, wy/wt))
+    (new GeometryFactory).createPoint(new Coordinate(wx/wt, wy/wt))
   }
 }


### PR DESCRIPTION
# Overview

This PR upgrades to GT 3.0. There are a few significant changes that deserve special attention in this regard:
1. Spray -> Circe
2. Geotrellis Geometries -> JTS Geometries
3. AWS SDK V1 -> AWS SDK V2
4. Overriding dependencies to avoid test failures due to `jackson` version 2.9 colliding with Spark's `jackson` version


Closes #115

