### PR TITLE
Move VectorPipe examples from azavea/osmesa

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `vectorpipe.examples`: VectorPipe examples moved from https://github.com/azavea/osmesa
+- `VectorPipe.defaultSparkSessionWithJTS` method to construct a VectorPipe tailored `SparkSession`. Users with more complicated use cases will still want to manually construct their own session.
+
 ### Changed
 
 ### Fixed

--- a/build.sbt
+++ b/build.sbt
@@ -124,6 +124,7 @@ val vpExtraSettings = Seq(
     gtGeotools exclude ("com.google.protobuf", "protobuf-java"),
     awscala,
     scalaj,
+    sparkHive % Provided,
     sparkSql % Provided,
     sparkJts,
     gtS3 exclude ("com.google.protobuf", "protobuf-java") exclude ("com.amazonaws", "aws-java-sdk-s3"),

--- a/src/main/scala/vectorpipe/examples/AugmentedDiffProcessor.scala
+++ b/src/main/scala/vectorpipe/examples/AugmentedDiffProcessor.scala
@@ -1,0 +1,76 @@
+package vectorpipe.examples
+
+import java.net.URI
+
+import cats.implicits._
+import com.monovore.decline._
+import org.apache.spark.sql._
+import vectorpipe.VectorPipe
+import vectorpipe.model.AugmentedDiff
+import vectorpipe.sources.Source
+
+/*
+ * Usage example:
+ *
+ * sbt assembly
+ *
+ * spark-submit \
+ *   --class vectorpipe.examples.AugmentedDiffProcessor \
+ *   target/scala-2.11/vectorpipe.jar \
+ *   --augmented-diff-source s3://somewhere/diffs/
+ */
+object AugmentedDiffProcessor
+    extends CommandApp(
+      name = "augmented-diff-processor",
+      header = "Read from augmented diffs",
+      main = {
+        val augmentedDiffSourceOpt = Opts.option[URI](
+          "augmented-diff-source",
+          short = "a",
+          metavar = "uri",
+          help = "Location of augmented diffs to process"
+        )
+        val startSequenceOpt = Opts
+          .option[Int](
+            "start-sequence",
+            short = "s",
+            metavar = "sequence",
+            help = "Starting sequence. If absent, the current (remote) sequence will be used."
+          )
+          .orNone
+        val endSequenceOpt = Opts
+          .option[Int](
+            "end-sequence",
+            short = "e",
+            metavar = "sequence",
+            help = "Ending sequence. If absent, the current (remote) sequence will be used."
+          )
+          .orNone
+
+        (augmentedDiffSourceOpt, startSequenceOpt, endSequenceOpt)
+          .mapN {
+            (augmentedDiffSource, startSequence, endSequence) =>
+              implicit val ss: SparkSession =
+                VectorPipe.defaultSparkSessionWithJTS("AugmentedDiffProcessor")
+
+              import ss.implicits._
+
+              val options = Map(Source.BaseURI -> augmentedDiffSource.toString) ++
+                startSequence
+                  .map(s => Map(Source.StartSequence -> s.toString))
+                  .getOrElse(Map.empty[String, String]) ++
+                endSequence
+                  .map(s => Map(Source.EndSequence -> s.toString))
+                  .getOrElse(Map.empty[String, String])
+
+              val geoms =
+                ss.read.format(Source.AugmentedDiffs).options(options).load
+
+              // aggregations are triggered when an event with a later timestamp ("event time") is received
+              // geoms.select('sequence).distinct.show
+              geoms.as[AugmentedDiff].show
+
+              ss.stop()
+          }
+      }
+    )

--- a/src/main/scala/vectorpipe/examples/AugmentedDiffStreamProcessor.scala
+++ b/src/main/scala/vectorpipe/examples/AugmentedDiffStreamProcessor.scala
@@ -1,0 +1,81 @@
+package vectorpipe.examples
+
+import java.net.URI
+
+import cats.implicits._
+import com.monovore.decline._
+import geotrellis.vector.{Feature, Geometry}
+import org.apache.spark.sql._
+import vectorpipe.VectorPipe
+import vectorpipe.model.ElementWithSequence
+import vectorpipe.sources.Source
+
+/*
+ * Usage example:
+ *
+ * sbt assembly
+ *
+ * spark-submit \
+ *   --class vectorpipe.examples.AugmentedDiffStreamProcessor \
+ *   target/scala-2.11/vectorpipe.jar \
+ *   --augmented-diff-source s3://somewhere/diffs/
+ */
+object AugmentedDiffStreamProcessor
+    extends CommandApp(
+      name = "augmented-diff-stream-processor",
+      header = "Read OSM augmented diffs as an open stream",
+      main = {
+        type AugmentedDiffFeature = Feature[Geometry, ElementWithSequence]
+
+        val augmentedDiffSourceOpt = Opts.option[URI](
+          "augmented-diff-source",
+          short = "a",
+          metavar = "uri",
+          help = "Location of augmented diffs to process"
+        )
+        val startSequenceOpt = Opts
+          .option[Int](
+            "start-sequence",
+            short = "s",
+            metavar = "sequence",
+            help = "Starting sequence. If absent, the current (remote) sequence will be used."
+          )
+          .orNone
+        val endSequenceOpt = Opts
+          .option[Int](
+            "end-sequence",
+            short = "e",
+            metavar = "sequence",
+            help = "Ending sequence. If absent, this will be an infinite stream."
+          )
+          .orNone
+
+        (augmentedDiffSourceOpt, startSequenceOpt, endSequenceOpt)
+          .mapN {
+            (augmentedDiffSource, startSequence, endSequence) =>
+              implicit val ss: SparkSession =
+                VectorPipe.defaultSparkSessionWithJTS("AugmentedDiffStreamProcessor")
+
+              val options = Map(Source.BaseURI -> augmentedDiffSource.toString,
+                                Source.ProcessName -> "AugmentedDiffStreamProcessor") ++
+                startSequence
+                  .map(s => Map(Source.StartSequence -> s.toString))
+                  .getOrElse(Map.empty[String, String]) ++
+                endSequence
+                  .map(s => Map(Source.EndSequence -> s.toString))
+                  .getOrElse(Map.empty[String, String])
+
+              val geoms =
+                ss.readStream.format(Source.AugmentedDiffs).options(options).load
+
+              // aggregations are triggered when an event with a later timestamp ("event time") is received
+              val query = geoms.writeStream
+                .format("console")
+                .start
+
+              query.awaitTermination()
+
+              ss.stop()
+          }
+      }
+    )

--- a/src/main/scala/vectorpipe/examples/ChangeProcessor.scala
+++ b/src/main/scala/vectorpipe/examples/ChangeProcessor.scala
@@ -1,0 +1,75 @@
+package vectorpipe.examples
+
+import java.net.URI
+
+import cats.implicits._
+import com.monovore.decline._
+import org.apache.spark.sql._
+import vectorpipe.VectorPipe
+import vectorpipe.model.Change
+import vectorpipe.sources.Source
+
+/*
+ * Usage example:
+ *
+ * sbt assembly
+ *
+ * spark-submit \
+ *   --class vectorpipe.examples.ChangeProcessor \
+ *   target/scala-2.11/vectorpipe.jar
+ */
+object ChangeProcessor
+  extends CommandApp(
+    name = "change-processor",
+    header = "Read minutely changes from start sequence to end sequence",
+    main = {
+      val changeSourceOpt = Opts
+        .option[URI]("change-source",
+        short = "d",
+        metavar = "uri",
+        help = "Location of minutely diffs to process")
+        .withDefault(new URI("https://planet.osm.org/replication/minute/"))
+      val startSequenceOpt = Opts
+        .option[Int](
+        "start-sequence",
+        short = "s",
+        metavar = "sequence",
+        help = "Starting sequence. If absent, the current (remote) sequence will be used."
+      )
+        .orNone
+      val endSequenceOpt = Opts
+        .option[Int](
+        "end-sequence",
+        short = "e",
+        metavar = "sequence",
+        help = "Ending sequence. If absent, this will be an infinite stream."
+      )
+        .orNone
+
+      (changeSourceOpt, startSequenceOpt, endSequenceOpt)
+        .mapN {
+          (changeSource, startSequence, endSequence) =>
+            implicit val ss: SparkSession =
+              VectorPipe.defaultSparkSessionWithJTS("ChangeProcessor")
+
+            import ss.implicits._
+
+            val options = Map(Source.BaseURI -> changeSource.toString) ++
+              startSequence
+                .map(s => Map(Source.StartSequence -> s.toString))
+                .getOrElse(Map.empty[String, String]) ++
+              endSequence
+                .map(s => Map(Source.EndSequence -> s.toString))
+                .getOrElse(Map.empty[String, String])
+
+            val changes =
+              ss.read.format(Source.Changes).options(options).load
+
+            // aggregations are triggered when an event with a later timestamp ("event time") is received
+            // changes.select('sequence).distinct.show
+            changes.as[Change].show
+
+            ss.stop()
+        }
+    }
+  )

--- a/src/main/scala/vectorpipe/examples/ChangeStreamProcessor.scala
+++ b/src/main/scala/vectorpipe/examples/ChangeStreamProcessor.scala
@@ -1,0 +1,81 @@
+package vectorpipe.examples
+
+import java.net.URI
+
+import cats.implicits._
+import com.monovore.decline._
+import org.apache.spark.sql._
+import vectorpipe.VectorPipe
+import vectorpipe.sources.Source
+
+/*
+ * Usage example:
+ *
+ * sbt assembly
+ *
+ * spark-submit \
+ *   --class vectorpipe.examples.ChangeStreamProcessor \
+ *   target/scala-2.11/vectorpipe.jar \
+ *   --augmented-diff-source s3://somewhere/diffs/
+ */
+object ChangeStreamProcessor
+    extends CommandApp(
+      name = "change-stream-processor",
+      header = "Read OSM minutely diffs as a stream",
+      main = {
+        val changeSourceOpt = Opts
+          .option[URI]("change-source",
+                       short = "d",
+                       metavar = "uri",
+                       help = "Location of minutely diffs to process")
+          .withDefault(new URI("https://planet.osm.org/replication/minute/"))
+        val startSequenceOpt = Opts
+          .option[Int](
+            "start-sequence",
+            short = "s",
+            metavar = "sequence",
+            help = "Starting sequence. If absent, the current (remote) sequence will be used."
+          )
+          .orNone
+        val endSequenceOpt = Opts
+          .option[Int](
+            "end-sequence",
+            short = "e",
+            metavar = "sequence",
+            help = "Ending sequence. If absent, this will be an infinite stream."
+          )
+          .orNone
+        val partitionCountOpt = Opts
+          .option[Int]("partitions",
+                       short = "p",
+                       metavar = "partition count",
+                       help = "Change partition count.")
+          .orNone
+
+        (changeSourceOpt, startSequenceOpt, endSequenceOpt, partitionCountOpt)
+          .mapN {
+            (changeSource, startSequence, endSequence, partitionCount) =>
+              implicit val ss: SparkSession =
+                VectorPipe.defaultSparkSessionWithJTS("ChangeStreamProcessor")
+
+              val options = Map(Source.BaseURI -> changeSource.toString, Source.ProcessName -> "ChangeStreamProcessor") ++
+                startSequence.map(s => Map(Source.StartSequence -> s.toString))
+                  .getOrElse(Map.empty[String, String]) ++
+                endSequence.map(s => Map(Source.EndSequence -> s.toString))
+                  .getOrElse(Map.empty[String, String]) ++
+                partitionCount.map(s => Map(Source.PartitionCount -> s.toString))
+                  .getOrElse(Map.empty[String, String])
+
+              val changes =
+                ss.readStream.format(Source.Changes).options(options).load
+
+              val query = changes.writeStream
+                .format("console")
+                .start
+
+              query.awaitTermination()
+
+              ss.stop()
+          }
+      }
+    )

--- a/src/main/scala/vectorpipe/examples/ChangesetProcessor.scala
+++ b/src/main/scala/vectorpipe/examples/ChangesetProcessor.scala
@@ -1,0 +1,75 @@
+package vectorpipe.examples
+
+import java.net.URI
+
+import cats.implicits._
+import com.monovore.decline._
+import org.apache.spark.sql._
+import vectorpipe.VectorPipe
+import vectorpipe.model.Changeset
+import vectorpipe.sources.Source
+
+/*
+ * Usage example:
+ *
+ * sbt assembly
+ *
+ * spark-submit \
+ *   --class vectorpipe.examples.ChangesetProcessor \
+ *   target/scala-2.11/vectorpipe.jar
+ */
+object ChangesetProcessor
+  extends CommandApp(
+    name = "changeset-processor",
+    header = "Read changesets between start sequence and end sequence",
+    main = {
+      val changesetSourceOpt =
+        Opts.option[URI]("changeset-source",
+          short = "c",
+          metavar = "uri",
+          help = "Location of changesets to process"
+        ).withDefault(new URI("https://planet.osm.org/replication/changesets/"))
+      val startSequenceOpt = Opts
+        .option[Int](
+        "start-sequence",
+        short = "s",
+        metavar = "sequence",
+        help = "Starting sequence. If absent, the current (remote) sequence will be used."
+      )
+        .orNone
+      val endSequenceOpt = Opts
+        .option[Int](
+        "end-sequence",
+        short = "e",
+        metavar = "sequence",
+        help = "Ending sequence. If absent, this will be an infinite stream."
+      )
+        .orNone
+
+      (changesetSourceOpt, startSequenceOpt, endSequenceOpt)
+        .mapN {
+          (changesetSource, startSequence, endSequence) =>
+            implicit val ss: SparkSession =
+              VectorPipe.defaultSparkSessionWithJTS("ChangesetProcessor")
+
+            import ss.implicits._
+
+            val options = Map(Source.BaseURI -> changesetSource.toString) ++
+              startSequence
+                .map(s => Map(Source.StartSequence -> s.toString))
+                .getOrElse(Map.empty[String, String]) ++
+              endSequence
+                .map(s => Map(Source.EndSequence -> s.toString))
+                .getOrElse(Map.empty[String, String])
+
+            val changes =
+              ss.read.format(Source.Changesets).options(options).load
+
+            // aggregations are triggered when an event with a later timestamp ("event time") is received
+            // changes.select('sequence).distinct.show
+            changes.as[Changeset].show
+
+            ss.stop()
+        }
+    }
+  )

--- a/src/main/scala/vectorpipe/examples/ChangesetStreamProcessor.scala
+++ b/src/main/scala/vectorpipe/examples/ChangesetStreamProcessor.scala
@@ -1,0 +1,81 @@
+package vectorpipe.examples
+
+import java.net.URI
+
+import cats.implicits._
+import com.monovore.decline._
+import org.apache.spark.sql._
+import vectorpipe.VectorPipe
+import vectorpipe.sources.Source
+
+/*
+ * Usage example:
+ *
+ * sbt assembly
+ *
+ * spark-submit \
+ *   --class vectorpipe.examples.ChangesetStreamProcessor \
+ *   target/scala-2.11/vectorpipe.jar \
+ *   --augmented-diff-source s3://somewhere/diffs/
+ */
+object ChangesetStreamProcessor
+  extends CommandApp(
+    name = "changeset-stream-processor",
+    header = "Read OSM changesets from start sequence to end sequence as a stream",
+    main = {
+      val changesetSourceOpt =
+        Opts.option[URI]("changeset-source",
+          short = "c",
+          metavar = "uri",
+          help = "Location of changesets to process"
+        ).withDefault(new URI("https://planet.osm.org/replication/changesets/"))
+      val startSequenceOpt = Opts
+        .option[Int](
+        "start-sequence",
+        short = "s",
+        metavar = "sequence",
+        help = "Starting sequence. If absent, the current (remote) sequence will be used."
+      )
+        .orNone
+      val endSequenceOpt = Opts
+        .option[Int](
+        "end-sequence",
+        short = "e",
+        metavar = "sequence",
+        help = "Ending sequence. If absent, this will be an infinite stream."
+      )
+        .orNone
+      val batchSizeOpt = Opts
+        .option[Int]("batch-size",
+        short = "b",
+        metavar = "batch size",
+        help = "Change batch size.")
+        .orNone
+
+      (changesetSourceOpt, startSequenceOpt, endSequenceOpt, batchSizeOpt)
+        .mapN {
+          (changesetSource, startSequence, endSequence, batchSize) =>
+            implicit val ss: SparkSession =
+              VectorPipe.defaultSparkSessionWithJTS("ChangesetStreamProcessor")
+
+            val options = Map(Source.BaseURI -> changesetSource.toString, Source.ProcessName -> "ChangesetStreamProcessor") ++
+              startSequence.map(s => Map(Source.StartSequence -> s.toString))
+                .getOrElse(Map.empty[String, String]) ++
+              endSequence.map(s => Map(Source.EndSequence -> s.toString))
+                .getOrElse(Map.empty[String, String]) ++
+              batchSize.map(s => Map(Source.BatchSize -> s.toString))
+                .getOrElse(Map.empty[String, String])
+
+            val changesets =
+              ss.readStream.format(Source.Changesets).options(options).load
+
+            val query = changesets.writeStream
+              .format("console")
+              .start
+
+            query.awaitTermination()
+
+            ss.stop()
+        }
+    }
+  )

--- a/src/test/scala/vectorpipe/TestEnvironment.scala
+++ b/src/test/scala/vectorpipe/TestEnvironment.scala
@@ -30,7 +30,7 @@ object TestEnvironment {
 trait TestEnvironment extends BeforeAndAfterAll { self: Suite with BeforeAndAfterAll =>
   implicit val ss: SparkSession = SparkSession.builder
     .master("local[*]")
-    .appName("OSMesa Test")
+    .appName("VectorPipe Test")
     .config("spark.ui.enabled", "false")
     .config("spark.default.parallelism","8")
     .config("spark.serializer", classOf[KryoSerializer].getName)


### PR DESCRIPTION
# Overview

Add stream processing examples with `Source`, `Changeset`, etc to `vectorpipe.examples`. These examples lived in [azavea/osmesa](https://github.com/azavea/osmesa) but were moved here as part of https://github.com/azavea/osmesa/pull/177 since they really demonstrate VectorPipe functionality.

The old examples all constructed a consistent, default SparkSession. That was moved here as well, and is now provided as `VectorPipe.defaultSparkSessionWithJTS`.

I elected not to split VP into subprojects at this time, the list of examples doesn't feel large or comprehensive enough yet to warrant it. Instead I opened https://github.com/geotrellis/vectorpipe/issues/123 for the future.

## Testing Instructions

You should be able to get these examples to run by following the docstring comment found in each. 

## Checklist

- [x] Add entry to CHANGELOG.md
