### PR TITLE
Documentation updates following CircleCI/Sonatype migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ package.
 
 Add the following to your `build.sbt`:
 ```
-libraryDependencies += "com.azavea.geotrellis" %% "vectorpipe" % "2.1.0"
+libraryDependencies += "com.azavea.geotrellis" %% "vectorpipe" % "2.1.1"
 ```
 
 **Note:** VectorPipe releases for version 2.0.0+ are hosted on SonaType. If you need earlier releases, they can be found on [Bintray](https://bintray.com/azavea/maven/vectorpipe). If using SBT for older releases, you will also need to include `resolvers ++= Resolver.bintrayRepo("azavea", "maven")` in your `build.sbt`.
@@ -40,7 +40,7 @@ libraryDependencies += "com.azavea.geotrellis" %% "vectorpipe" % "2.1.0"
 
 The fastest way to get started with VectorPipe in a REPL is to invoke `spark-shell`:
 ```bash
-spark-shell --packages com.azavea.geotrellis:vectorpipe_2.11:2.1.0
+spark-shell --packages com.azavea.geotrellis:vectorpipe_2.11:2.1.1
 ```
 
 This will download the required components and set up a REPL with VectorPipe

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/447170921bc94b3fb494bb2b965c2235)](https://www.codacy.com/app/fosskers/vectorpipe?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=geotrellis/vectorpipe&amp;utm_campaign=Badge_Grade)
 
 VectorPipe (VP) is a library for working with OpenStreetMap (OSM) vector
-data. Powered by [Geotrellis](http://geotrellis.io) and [Apache
-Spark](http://spark.apache.org/).
+data and writing geometries to vector tile layers. Powered by [Geotrellis](http://geotrellis.io)
+and [Apache Spark](http://spark.apache.org/).
 
 OSM provides a wealth of data which has broad coverage and a deep history.
 This comes at the price of very large size which can make accessing the power
@@ -29,10 +29,18 @@ package.
 
 ## Getting Started ##
 
-The fastest way to get started with VectorPipe is to invoke `spark-shell` and
-load the package jars from the Bintray repository:
+Add the following to your `build.sbt`:
+```
+libraryDependencies += "com.azavea.geotrellis" %% "vectorpipe" % "2.1.0"
+```
+
+**Note:** VectorPipe releases for version 2.0.0+ are hosted on SonaType. If you need earlier releases, they can be found on [Bintray](https://bintray.com/azavea/maven/vectorpipe). If using SBT for older releases, you will also need to include `resolvers ++= Resolver.bintrayRepo("azavea", "maven")` in your `build.sbt`.
+
+### With a REPL
+
+The fastest way to get started with VectorPipe in a REPL is to invoke `spark-shell`:
 ```bash
-spark-shell --packages com.azavea:vectorpipe_2.11:1.1.0 --repositories http://dl.bintray.com/azavea/maven
+spark-shell --packages com.azavea.geotrellis:vectorpipe_2.11:2.1.0
 ```
 
 This will download the required components and set up a REPL with VectorPipe

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # VectorPipe #
 
-[![Build Status](https://travis-ci.org/geotrellis/vectorpipe.svg?branch=master)](https://travis-ci.org/geotrellis/vectorpipe)
-[![Bintray](https://img.shields.io/bintray/v/azavea/maven/vectorpipe.svg)](https://bintray.com/azavea/maven/vectorpipe)
+[![CircleCI](https://circleci.com/gh/geotrellis/vectorpipe/tree/master.svg?style=svg)](https://circleci.com/gh/geotrellis/vectorpipe/tree/master)
+[![SonaType Releases](https://img.shields.io/nexus/r/com.azavea.geotrellis/vectorpipe_2.11?label=SonaType%20Nexus&logo=vectorpipe&server=https%3A%2F%2Foss.sonatype.org)](https://oss.sonatype.org/#nexus-search;quick~vectorpipe)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/447170921bc94b3fb494bb2b965c2235)](https://www.codacy.com/app/fosskers/vectorpipe?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=geotrellis/vectorpipe&amp;utm_campaign=Badge_Grade)
 
 VectorPipe (VP) is a library for working with OpenStreetMap (OSM) vector

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,20 +1,12 @@
-# Releasing
+# Publishing a release
 
-When releasing, ensure you have write access to the `azavea` 
-bintray organization. You can configure your credentials by
-following the prompts after running `./sbt bintrayChangeCredentials`
-
-## Publishing a release
-
-1. Create a new release branch from up-to-date master, e.g. `release/x.y.z`
-1. Bump version refs in README
-1. Bump version ref in `project/Version.scala`
-1. Review CHANGELOG.md. Move `[Unreleased]` header to empty section and replace with `[x.y.z]` header plus release date. 
+1. Create a new release branch from up-to-date master named `release/x.y.z`
+1. Review CHANGELOG.md. Move `[Unreleased]` header to empty section and replace with `[x.y.z]` header plus release date.
+1. Update the version numbers in the build.sbt and spark-shell examples in the README's "Getting Started" section.
 1. Commit these changes as a single commit, with the message "Release vx.y.z"
 1. Push branch and make a PR on GitHub
 1. Ensure CI succeeds
-1. Ensure there are no new commits on master, then merge. If there are new commits, rebase this branch on master and start over at step 2 if you wish to include them.
-1. Tag the merge commit: `git tag -a vx.y.z -m "Release x.y.z"`
-1. Publish the tagged commit as a new release: `./sbt publish`
+1. Ensure there are no new commits on master. If there are new commits, rebase this branch on master and start over at step 2 if you wish to include them. Otherwise, merge.
+1. Tag the merge commit on the master branch: `git tag -a vx.y.z -m "Release x.y.z"`
 1. Push the new tag: `git push --tags`
-
+1. Review the CircleCI build status to ensure that the tag was successfully published to SonaType.


### PR DESCRIPTION
Brings README + RELEASING markdown files up to date. I just ran through the `v2.1.0` release following these new instructions. 

Connects #120 

Closes #126 

