### PR TITLE
Fixup bugs in VectorPipe that prevent examples from running

### DIFF
--- a/src/main/scala/vectorpipe/model/ElementWithSequence.scala
+++ b/src/main/scala/vectorpipe/model/ElementWithSequence.scala
@@ -39,7 +39,7 @@ object ElementWithSequence {
         id <- c.downField("id").as[Long]
         `type` <- c.downField("type").as[String]
         tags <- c.downField("tags").as[Map[String, String]]
-        nds <- c.downField("nds").as[Seq[Long]]
+        nds <- c.downField("nds").as[Option[Seq[Long]]]
         changeset <- c.downField("changeset").as[Long]
         timestampS <- c.downField("timestamp").as[String]
         uid <- c.downField("uid").as[Long]
@@ -47,9 +47,8 @@ object ElementWithSequence {
         version <- c.downField("version").as[Int]
         visible <- c.downField("visible").as[Option[Boolean]]
         sequence <- c.downField("augmentedDiff").as[Option[Long]]
-
       } yield {
-        val timestamp = 
+        val timestamp =
           Timestamp.from(
             ISODateTimeFormat
               .dateTimeParser()
@@ -57,12 +56,11 @@ object ElementWithSequence {
               .toDate
               .toInstant
           )
-
         model.ElementWithSequence(
           id,
           `type`,
           tags,
-          nds,
+          nds.getOrElse(Seq.empty[Long]),
           changeset,
           timestamp,
           uid,

--- a/src/main/scala/vectorpipe/sources/ChangeMicroBatchReader.scala
+++ b/src/main/scala/vectorpipe/sources/ChangeMicroBatchReader.scala
@@ -24,7 +24,7 @@ class ChangeStreamBatchReader(baseURI: URI, sequences: Seq[Int])
 
 case class ChangeMicroBatchReader(options: DataSourceOptions, checkpointLocation: String)
     extends ReplicationStreamMicroBatchReader[Change](options, checkpointLocation) {
-  private val baseURI = new URI(
+  private lazy val baseURI = new URI(
     options
       .get(Source.BaseURI)
       .orElse("https://planet.osm.org/replication/minute/")

--- a/src/main/scala/vectorpipe/sources/ChangesetMicroBatchReader.scala
+++ b/src/main/scala/vectorpipe/sources/ChangesetMicroBatchReader.scala
@@ -25,7 +25,7 @@ class ChangesetStreamBatchReader(baseURI: URI, sequences: Seq[Int])
 
 class ChangesetMicroBatchReader(options: DataSourceOptions, checkpointLocation: String)
     extends ReplicationStreamMicroBatchReader[Changeset](options, checkpointLocation) {
-  private val baseURI = new URI(
+  private lazy val baseURI = new URI(
     options
       .get(Source.BaseURI)
       .orElse("https://planet.osm.org/replication/changesets/")


### PR DESCRIPTION
With these changes applied, I was able to run all six new examples in the `vectorpipe.examples` directory. These bugs were likely fallout from the GT 3.1 / Spark 2.4 upgrade and were only exposed with runnable examples in the project.

## Testing

Run each of the examples using default arguments, they should now all pass. For example:
```
./sbt
> test:runMain test:runMain vectorpipe.examples.ChangesetStreamProcessor
```
For the AugmentedDiff examples you'll need to correctly set AWS_PROFILE and pass an s3 augmented diff location for `--augmented-diff-source`.

