### PR TITLE
fixup: changed AWS SDK 404 exception in v2

### DIFF
--- a/src/main/scala/vectorpipe/sources/AugmentedDiffSource.scala
+++ b/src/main/scala/vectorpipe/sources/AugmentedDiffSource.scala
@@ -23,8 +23,7 @@ import io.circe._
 import io.circe.generic.auto._
 import cats.implicits._
 
-import com.amazonaws.services.s3.model.AmazonS3Exception
-import software.amazon.awssdk.services.s3.model.GetObjectRequest
+import software.amazon.awssdk.services.s3.model.{GetObjectRequest, NoSuchKeyException}
 import software.amazon.awssdk.services.s3.S3Client
 import com.softwaremill.macmemo.memoize
 import org.joda.time.DateTime
@@ -75,7 +74,7 @@ object AugmentedDiffSource extends Logging {
         gzis.close()
       }
     } catch {
-      case e: AmazonS3Exception if e.getStatusCode == 404 || e.getStatusCode == 403 =>
+      case _: NoSuchKeyException =>
         getCurrentSequence(baseURI) match {
           case Some(s) if s > sequence =>
             logInfo("Encountered missing sequence, comparing with current for validity")


### PR DESCRIPTION
## Notes

We need to catch the correct NoSuchKeyException from
the v2 client. We were catching a v1 client exception.

## Demo
Bah. I missed one more. This gets the osmesa.apps.streaming.AOIMonitor fully working. Example run:
![Screen Shot 2019-12-17 at 10 08 05 AM](https://user-images.githubusercontent.com/1818302/71007575-3b0b7f00-20b5-11ea-9d7d-d080414cf502.png)


