### PR TITLE
Catch S3 403s again in addition to 404s

### DIFF
--- a/src/main/scala/vectorpipe/sources/AugmentedDiffSource.scala
+++ b/src/main/scala/vectorpipe/sources/AugmentedDiffSource.scala
@@ -23,7 +23,7 @@ import io.circe._
 import io.circe.generic.auto._
 import cats.implicits._
 
-import software.amazon.awssdk.services.s3.model.{GetObjectRequest, NoSuchKeyException}
+import software.amazon.awssdk.services.s3.model.{GetObjectRequest, NoSuchKeyException, S3Exception}
 import software.amazon.awssdk.services.s3.S3Client
 import com.softwaremill.macmemo.memoize
 import org.joda.time.DateTime
@@ -74,7 +74,7 @@ object AugmentedDiffSource extends Logging {
         gzis.close()
       }
     } catch {
-      case _: NoSuchKeyException =>
+      case e: S3Exception if e.isInstanceOf[NoSuchKeyException] || e.statusCode == 403 =>
         getCurrentSequence(baseURI) match {
           case Some(s) if s > sequence =>
             logInfo("Encountered missing sequence, comparing with current for validity")


### PR DESCRIPTION
These 403s don't have a specific subclass,
so we catch the error that was thrown when
this code was run:

software.amazon.awssdk.services.s3.model.S3Exception:
  Access Denied (Service: S3, Status Code: 403, Request ID: _)

Fallout from GT3.1 upgrade, we should have caught this exception
in #129 as well to properly refactor from VP 1.0 days.

## Demo

No 404/403 errors from process run locally:
<img width="1207" alt="Screen Shot 2019-12-18 at 11 23 50 AM" src="https://user-images.githubusercontent.com/1818302/71104327-a030a480-2189-11ea-9eac-bc24a1d516d1.png">
<img width="1046" alt="Screen Shot 2019-12-18 at 11 24 04 AM" src="https://user-images.githubusercontent.com/1818302/71104328-a030a480-2189-11ea-8ad4-7f3ce5a87955.png">

