### PR TITLE
Add call to ensureCompressedMembers in preprocessRelations

### DIFF
--- a/src/main/scala/vectorpipe/internal/package.scala
+++ b/src/main/scala/vectorpipe/internal/package.scala
@@ -136,10 +136,11 @@ package object internal {
     } else {
       @transient val idByUpdated = Window.partitionBy('id).orderBy('version)
 
+      val relations = ensureCompressedMembers(history.where('type === "relation"))
+
       // when an element has been deleted, it doesn't include any tags; use a window function to retrieve the last tags
       // present and use those
-      history
-        .where('type === "relation")
+      relations
         .repartition('id)
         .select(
           'id,

--- a/src/test/scala/vectorpipe/ProcessOSMTest.scala
+++ b/src/test/scala/vectorpipe/ProcessOSMTest.scala
@@ -2,7 +2,6 @@ package vectorpipe
 
 import org.scalatest._
 import vectorpipe.{internal => ProcessOSM}
-import vectorpipe.functions.osm.ensureCompressedMembers
 
 class ProcessOSMTest extends FunSpec with TestEnvironment with Matchers {
   val orcFile = getClass.getResource("/isle-of-man-latest.osm.orc").getPath
@@ -11,7 +10,7 @@ class ProcessOSMTest extends FunSpec with TestEnvironment with Matchers {
   val nodes = ProcessOSM.preprocessNodes(elements).cache
   val nodeGeoms = ProcessOSM.constructPointGeometries(nodes).cache
   val wayGeoms = ProcessOSM.reconstructWayGeometries(elements, nodes).cache
-  val relationGeoms = ProcessOSM.reconstructRelationGeometries(ensureCompressedMembers(elements), wayGeoms).cache
+  val relationGeoms = ProcessOSM.reconstructRelationGeometries(elements, wayGeoms).cache
 
   it("parses isle of man nodes") {
     info(s"Nodes: ${nodeGeoms.count}")


### PR DESCRIPTION
# Overview

The README claims the String to Byte conversion or relation member `type` is "handled for you" in the top-level OSM object, but that is not the case.  So this PR adds a call to `ensureCompressedMembers` within `preprocessRelations` to the filtered `"relation"` records which will have non-empty `members` arrays.
Note: I figured it made sense to do this conversion when pre-processing input relations rather than only in the top-level OSM object (as the README claims).

## Notes

See Issue https://github.com/geotrellis/vectorpipe/issues/134

## Testing Instructions

The counts printed by `ProcessOSMTest` did not change after this change, and I removed the call to `ensureCompressedMembers` on the input test data since that would now be redundant.

## Checklist

- [ ] Add entry to CHANGELOG.md 

Closes #134

