### PR TITLE
Update Geotrellis version to 3.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `VectorPipe.Options` to support for any square layout level (not just from ZoomedLayoutScheme)
 - `Pipeline#baseOutputURI` moved to `Pipeline.Output#baseOutputURI`
+- Updated Geotrellis dependency to 3.5.1
 
 ### Fixed
 

--- a/project/Version.scala
+++ b/project/Version.scala
@@ -1,8 +1,8 @@
 object Version {
   val awscala = "0.8.1"
-  val geotrellis = "3.1.0"
+  val geotrellis = "3.5.1"
   val scala2_11 = "2.11.12"
-  val scala2_12 = "2.12.8"
+  val scala2_12 = "2.12.12"
   val geomesa = "2.2.1"
   val decline = "0.6.1"
   val cats = "1.6.1"


### PR DESCRIPTION
# Overview

We are currently lagging behind the GT release schedule.  This PR bumps up to parity.

## Checklist

- [X] Add entry to CHANGELOG.md 

