### PR TITLE
Improve robustness of changeset lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `VectorPipe.Options` to support for any square layout level (not just from ZoomedLayoutScheme)
 - `Pipeline#baseOutputURI` moved to `Pipeline.Output#baseOutputURI`
 - Updated Geotrellis dependency to 3.5.1
+- Improve robustness of functions in `vectorpipe.sources.ChangesetSource`
 
 ### Fixed
 

--- a/src/main/scala/vectorpipe/sources/ChangesetSource.scala
+++ b/src/main/scala/vectorpipe/sources/ChangesetSource.scala
@@ -7,7 +7,6 @@ import java.time.Instant
 import java.util.zip.GZIPInputStream
 
 import cats.implicits._
-import com.softwaremill.macmemo.memoize
 import io.circe.generic.auto._
 import io.circe.{yaml, _}
 import org.apache.commons.io.IOUtils
@@ -18,6 +17,7 @@ import vectorpipe.model.Changeset
 import scalaj.http.Http
 
 import scala.concurrent.duration.{Duration, _}
+import scala.util.Try
 import scala.xml.XML
 
 object ChangesetSource extends Logging {
@@ -28,7 +28,7 @@ object ChangesetSource extends Logging {
   private implicit val dateTimeDecoder: Decoder[DateTime] =
     Decoder.instance(a => a.as[String].map(DateTime.parse(_, formatter)))
 
-  def getChangeset(baseURI: URI, sequence: Int): Seq[Changeset] = {
+  def getChangeset(baseURI: URI, sequence: Int, retry: Boolean = true): Seq[Changeset] = {
     val s = f"$sequence%09d"
     val path = s"${s.slice(0, 3)}/${s.slice(3, 6)}/${s.slice(6, 9)}.osm.gz"
 
@@ -39,9 +39,14 @@ object ChangesetSource extends Logging {
         Http(baseURI.resolve(path).toString).asBytes
 
       if (response.code == 404) {
-        logDebug(s"$sequence is not yet available, sleeping.")
-        Thread.sleep(Delay.toMillis)
-        getChangeset(baseURI, sequence)
+        if (retry) {
+          logDebug(s"$sequence is not yet available, sleeping.")
+          Thread.sleep(Delay.toMillis)
+          getChangeset(baseURI, sequence)
+        } else {
+          logDebug(s"$sequence is yet available")
+          Seq()
+        }
       } else {
         // NOTE: if diff bodies get really large, switch to a SAX parser to help with the memory footprint
         val bais = new ByteArrayInputStream(response.body)
@@ -69,27 +74,36 @@ object ChangesetSource extends Logging {
 
   case class Sequence(last_run: DateTime, sequence: Long)
 
-  @memoize(maxSize = 1, expiresAfter = 30 seconds)
+  private def grabSequence(baseURI: URI, filename: String): Sequence = {
+    val response =
+      Http(baseURI.resolve("state.yaml").toString).asString
+
+    val state = yaml.parser
+      .parse(response.body)
+      .leftMap(err => err: Error)
+      .flatMap(_.as[Sequence])
+      .valueOr(throw _)
+
+    state
+  }
+
   def getCurrentSequence(baseURI: URI): Option[Sequence] = {
-    try {
-      val response =
-        Http(baseURI.resolve("state.yaml").toString).asString
+    var state: Try[Sequence] = null
 
-      val state = yaml.parser
-        .parse(response.body)
-        .leftMap(err => err: Error)
-        .flatMap(_.as[Sequence])
-        .valueOr(throw _)
+    for (i <- Range(0, 5)) {
+      state = Try(grabSequence(baseURI, "state.yaml"))
 
-      logDebug(s"$baseURI state: ${state.sequence} @ ${state.last_run}")
+      if (state.isSuccess) {
+        logDebug(s"$baseURI state: ${state.get.sequence} @ ${state.get.last_run}")
 
-      Some(state)
-    } catch {
-      case err: Throwable =>
-        logError("Error fetching / parsing changeset state.", err)
+        return Some(state.get)
+      }
 
-        None
+      Thread.sleep(5000)
     }
+
+    logError("Error fetching / parsing changeset state.", state.failed.get)
+    None
   }
 
   def getSequence(baseURI: URI, sequence: Long): Option[Sequence] = {
@@ -97,14 +111,7 @@ object ChangesetSource extends Logging {
     val path = s"${s.slice(0, 3)}/${s.slice(3, 6)}/${s.slice(6, 9)}.state.txt"
 
     try {
-      val response =
-        Http(baseURI.resolve(path).toString).asString
-
-      val state = yaml.parser
-        .parse(response.body)
-        .leftMap(err => err: Error)
-        .flatMap(_.as[Sequence])
-        .valueOr(throw _)
+      val state = grabSequence(baseURI, path)
 
       Some(state)
     } catch {
@@ -115,19 +122,45 @@ object ChangesetSource extends Logging {
     }
   }
 
-  def estimateSequenceNumber(modifiedTime: Instant, baseURI: URI): Long = {
+  def estimateSequenceNumber(modifiedTime: Instant, baseURI: URI, maxIters: Int = 1000): Long = {
     val current = getCurrentSequence(baseURI)
-    val diffMinutes = (current.get.last_run.toInstant.getMillis/1000 - modifiedTime.getEpochSecond) / 60
-    current.get.sequence - diffMinutes
+    if (current.isDefined) {
+      val diffMinutes = (current.get.last_run.getMillis/1000 -
+                         modifiedTime.getEpochSecond) / 60
+      current.get.sequence - diffMinutes
+    } else {
+      // Some queries on the state.yaml fail, set up a failsafe
+      // ###.state.txt may not be provided for all replications, so use changsets
+      var i = 0
+      var baseTime: Long = -1
+      while (baseTime == -1 && i < maxIters) {
+        baseTime = getChangeset(baseURI, i, false).map(_.createdAt.toInstant.getEpochSecond).sorted.lastOption.getOrElse(-1L)
+        i += 1
+      }
+      if (i == maxIters)
+        throw new IndexOutOfBoundsException(s"Couldn't find non-empty changeset in ${maxIters} attempts")
+
+      val query = modifiedTime.getEpochSecond
+
+      (query - baseTime) / 60 + i
+    }
+  }
+
+  private def safeSequenceTime(baseURI: URI, sequence: Long): Option[Instant] = {
+    val res = getSequence(baseURI, sequence)
+    if (res.isDefined) {
+      Some(Instant.parse(res.get.last_run.toString))
+    } else {
+      getChangeset(baseURI, sequence.toInt, false).map(_.createdAt.toInstant).sortBy(_.getEpochSecond).lastOption.map{ inst => Instant.parse(inst.toString).plusSeconds(60) }
+    }
   }
 
   def findSequenceFor(modifiedTime: Instant, baseURI: URI): Long = {
     var guess = estimateSequenceNumber(modifiedTime, baseURI)
-    val target = org.joda.time.Instant.parse(modifiedTime.toString)
 
-    while (getSequence(baseURI, guess).get.last_run.isAfter(target)) { guess -= 1 }
-    while (getSequence(baseURI, guess).get.last_run.isBefore(target)) { guess += 1 }
+    while (safeSequenceTime(baseURI, guess).map(_.isAfter(modifiedTime)).getOrElse(false)) { guess -= 1 }
+    while (safeSequenceTime(baseURI, guess).map(_.isBefore(modifiedTime)).getOrElse(false)) { guess += 1 }
 
-    getSequence(baseURI, guess).get.sequence
+    guess
   }
 }


### PR DESCRIPTION
# Overview

In `vectorpipe.sources.ChangesetSource`, there are a set of functions for locating a changeset in a replication stream corresponding to a given date.  These functions could fail for a variety of reasons, leading to unexplained `None.get` errors like
```
20/12/28 20:59:31 ERROR Client: Application diagnostics message: User class threw exception: java.util.NoSuchElementException: None.get
	at scala.None$.get(Option.scala:347)
	at scala.None$.get(Option.scala:345)
	at vectorpipe.sources.ChangesetSource$.estimateSequenceNumber(ChangesetSource.scala:120)
	at vectorpipe.sources.ChangesetSource$.findSequenceFor(ChangesetSource.scala:125)
...
```

These errors are transient, so hard to test.  The fixes taken up in this contribution are to attempt to define better fallback behavior.  For instance, when `###.state.txt` files are not available for some sequence number (this is true for many sequences in OSM proper), we defer to the associated `###.osm.gz`, and attempt to estimate the `last_run` for that sequence from the contained changesets.

These approximations may lead to substantially worse estimates, and therefore longer runtimes, but processes will not fail suddenly.  If there were any indication why functions such as `getCurrentSequence` fail, we might be able to implement more targeted fixes.  This PR represents naïve solutions that will hopefully lower the failure rate.

## Testing Instructions

I am open to suggestions for how to test this without setting up a mock replication stream, which may be time consuming to achieve.

## Checklist

- [X] Add entry to CHANGELOG.md 

Closes #143 