### PR TITLE
Introduce robust augmented diff parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `RobustFeature` infrastructure added to allow handling of diffs containing bad geometries.
+
 ### Changed
 
 ### Fixed

--- a/project/Version.scala
+++ b/project/Version.scala
@@ -1,6 +1,6 @@
 object Version {
   val awscala = "0.8.1"
-  val vectorpipe = "1.2.0-SNAPSHOT"
+  val vectorpipe = "1.2.0"
   val scala = "2.11.12"
   val geotrellis = "2.2.0"
   val geomesa = "2.2.1"

--- a/project/Version.scala
+++ b/project/Version.scala
@@ -1,6 +1,6 @@
 object Version {
   val awscala = "0.8.1"
-  val vectorpipe = "1.1.0"
+  val vectorpipe = "1.2.0-SNAPSHOT"
   val scala = "2.11.12"
   val geotrellis = "2.2.0"
   val geomesa = "2.2.1"

--- a/src/main/scala/vectorpipe/sources/AugmentedDiffMicroBatchReader.scala
+++ b/src/main/scala/vectorpipe/sources/AugmentedDiffMicroBatchReader.scala
@@ -3,6 +3,7 @@ package vectorpipe.sources
 import java.net.URI
 import java.util
 
+import org.apache.spark.internal.Logging
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.sources.v2.DataSourceOptions
 import org.apache.spark.sql.sources.v2.reader.{DataReader, DataReaderFactory}
@@ -11,21 +12,22 @@ import vectorpipe.model.AugmentedDiff
 import scala.collection.JavaConverters._
 import scala.compat.java8.OptionConverters._
 
-case class AugmentedDiffStreamBatchTask(baseURI: URI, sequences: Seq[Int])
+case class AugmentedDiffStreamBatchTask(baseURI: URI, sequences: Seq[Int], handler: (Int, AugmentedDiffSource.RF) => Unit)
     extends DataReaderFactory[Row] {
   override def createDataReader(): DataReader[Row] =
-    AugmentedDiffStreamBatchReader(baseURI, sequences)
+    AugmentedDiffStreamBatchReader(baseURI, sequences, handler)
 }
 
-case class AugmentedDiffStreamBatchReader(baseURI: URI, sequences: Seq[Int])
+case class AugmentedDiffStreamBatchReader(baseURI: URI, sequences: Seq[Int], handler: (Int, AugmentedDiffSource.RF) => Unit)
     extends ReplicationStreamBatchReader[AugmentedDiff](baseURI, sequences) {
 
   override def getSequence(baseURI: URI, sequence: Int): Seq[AugmentedDiff] =
-    AugmentedDiffSource.getSequence(baseURI, sequence)
+    AugmentedDiffSource.getSequence(baseURI, sequence, handler)
 }
 
 case class AugmentedDiffMicroBatchReader(options: DataSourceOptions, checkpointLocation: String)
-    extends ReplicationStreamMicroBatchReader[AugmentedDiff](options, checkpointLocation) {
+    extends ReplicationStreamMicroBatchReader[AugmentedDiff](options, checkpointLocation)
+    with Logging {
 
   override def getCurrentSequence: Option[Int] =
     AugmentedDiffSource.getCurrentSequence(baseURI)
@@ -41,9 +43,20 @@ case class AugmentedDiffMicroBatchReader(options: DataSourceOptions, checkpointL
         )
       )
 
+  private def errorHandler: AugmentedDiffSourceErrorHandler = {
+    val handlerClass = options
+      .get(Source.ErrorHandler)
+      .asScala
+      .getOrElse("vectorpipe.sources.AugmentedDiffSourceErrorHandler")
+
+    val handler = Class.forName(handlerClass).newInstance.asInstanceOf[AugmentedDiffSourceErrorHandler]
+    handler.setOptions(options.asMap.asScala.toMap)
+    handler
+  }
+
   override def createDataReaderFactories(): util.List[DataReaderFactory[Row]] =
     sequenceRange
       .map(seq =>
-        AugmentedDiffStreamBatchTask(baseURI, Seq(seq)).asInstanceOf[DataReaderFactory[Row]])
+        AugmentedDiffStreamBatchTask(baseURI, Seq(seq), errorHandler.handle).asInstanceOf[DataReaderFactory[Row]])
       .asJava
 }

--- a/src/main/scala/vectorpipe/sources/AugmentedDiffProvider.scala
+++ b/src/main/scala/vectorpipe/sources/AugmentedDiffProvider.scala
@@ -33,6 +33,7 @@ class AugmentedDiffProvider
   }
 
   override def shortName(): String = Source.AugmentedDiffs
-  override def createReader(options: DataSourceOptions): DataSourceReader =
+  override def createReader(options: DataSourceOptions): DataSourceReader = {
     AugmentedDiffReader(options)
+  }
 }

--- a/src/main/scala/vectorpipe/sources/AugmentedDiffSource.scala
+++ b/src/main/scala/vectorpipe/sources/AugmentedDiffSource.scala
@@ -76,12 +76,6 @@ object AugmentedDiffSource extends Logging {
    * file is available.
    */
   def getSequence(baseURI: URI, sequence: Int, badGeometryHandler: (Int, RF) => Unit, waitUntilAvailable: Boolean): Seq[AugmentedDiff] = {
-    val bucket = baseURI.getHost
-    val prefix = new File(baseURI.getPath.drop(1)).toPath
-    // left-pad sequence
-    val s = f"$sequence%09d"
-    val key = prefix.resolve(s"${s.slice(0, 3)}/${s.slice(3, 6)}/${s.slice(6, 9)}.json.gz").toString
-
     logDebug(s"Fetching sequence $sequence")
 
     try {

--- a/src/main/scala/vectorpipe/sources/AugmentedDiffSource.scala
+++ b/src/main/scala/vectorpipe/sources/AugmentedDiffSource.scala
@@ -12,8 +12,7 @@ import com.amazonaws.services.s3.model.AmazonS3Exception
 import com.softwaremill.macmemo.memoize
 import geotrellis.spark.io.s3.{AmazonS3Client, S3Client}
 import geotrellis.vector.io._
-import geotrellis.vector.io.json.JsonFeatureCollectionMap
-import geotrellis.vector.{Feature, Geometry}
+import geotrellis.vector.Geometry
 import io.circe.generic.auto._
 import io.circe.{yaml, _}
 import org.apache.commons.io.IOUtils
@@ -22,17 +21,61 @@ import org.apache.spark.sql.Column
 import org.apache.spark.sql.functions.{floor, from_unixtime, to_timestamp, unix_timestamp}
 import org.joda.time.DateTime
 import vectorpipe.model.{AugmentedDiff, ElementWithSequence}
+import vectorpipe.util._
+import vectorpipe.util.RobustFeatureFormats._
 
 import scala.concurrent.duration.{Duration, _}
 
 object AugmentedDiffSource extends Logging {
+  type RF = RobustFeature[Geometry, ElementWithSequence]
+
   private lazy val s3: AmazonS3Client = S3Client.DEFAULT
   val Delay: Duration = 15.seconds
 
   private implicit val dateTimeDecoder: Decoder[DateTime] =
     Decoder.instance(a => a.as[String].map(DateTime.parse))
 
-  def getSequence(baseURI: URI, sequence: Int): Seq[AugmentedDiff] = {
+  def getFeatures(baseURI: URI, sequence: Int): Seq[Map[String, RF]] = {
+    val bucket = baseURI.getHost
+    val prefix = new File(baseURI.getPath.drop(1)).toPath
+    // left-pad sequence
+    val s = f"$sequence%09d"
+    val key = prefix.resolve(s"${s.slice(0, 3)}/${s.slice(3, 6)}/${s.slice(6, 9)}.json.gz").toString
+
+    logDebug(s"Fetching sequence $sequence")
+
+    val bais = new ByteArrayInputStream(s3.readBytes(bucket, key))
+    val gzis = new GZIPInputStream(bais)
+
+    try {
+      IOUtils
+        .toString(gzis, StandardCharsets.UTF_8)
+        .lines
+        .map { line =>
+        // Spark doesn't like RS-delimited JSON; perhaps Spray doesn't either
+        line
+          .replace("\u001e", "")
+          .parseGeoJson[JsonRobustFeatureCollectionMap]
+          .getAll[RobustFeature[Geometry, ElementWithSequence]]
+      }
+      .toSeq
+    } finally {
+      gzis.close()
+      bais.close()
+    }
+  }
+
+  /**
+   * Fetch all augmented diffs from a sequence number.
+   *
+   * This function collects the data in an augmented diff sequence file into
+   * vectorpipe.model.AugmentedDiff objects.  These diff files are expected to be
+   * stored on S3 in .json.gz files.  This method provides the option to process errors
+   * generated when the new geometry in the diff is faulty.  If `waitUntilAvailable` is
+   * set to true, the process will block, in 15 second increments, until the sequence
+   * file is available.
+   */
+  def getSequence(baseURI: URI, sequence: Int, badGeometryHandler: (Int, RF) => Unit, waitUntilAvailable: Boolean): Seq[AugmentedDiff] = {
     val bucket = baseURI.getHost
     val prefix = new File(baseURI.getPath.drop(1)).toPath
     // left-pad sequence
@@ -42,26 +85,11 @@ object AugmentedDiffSource extends Logging {
     logDebug(s"Fetching sequence $sequence")
 
     try {
-      val bais = new ByteArrayInputStream(s3.readBytes(bucket, key))
-      val gzis = new GZIPInputStream(bais)
+      val robustFeatureMaps = getFeatures(baseURI, sequence)
 
-      try {
-        IOUtils
-          .toString(gzis, StandardCharsets.UTF_8)
-          .lines
-          .map { line =>
-            // Spark doesn't like RS-delimited JSON; perhaps Spray doesn't either
-            val features = line
-              .replace("\u001e", "")
-              .parseGeoJson[JsonFeatureCollectionMap]
-              .getAll[Feature[Geometry, ElementWithSequence]]
-
-            AugmentedDiff(sequence, features.get("old"), features("new"))
-          }
-          .toSeq
-      } finally {
-        gzis.close()
-        bais.close()
+      robustFeatureMaps.map{ m =>
+        if (m.contains("new") && !m("new").geom.isDefined) badGeometryHandler(sequence, m("new"))
+        AugmentedDiff(sequence, m.get("old").map(_.toFeature), m("new").toFeature)
       }
     } catch {
       case e: AmazonS3Exception if e.getStatusCode == 404 || e.getStatusCode == 403 =>
@@ -71,16 +99,31 @@ object AugmentedDiffSource extends Logging {
             // sequence is missing; this is intentional, so compare with currentSequence for validity
             Seq.empty[AugmentedDiff]
           case _ =>
-            logInfo(s"$sequence is not yet available, sleeping.")
-            Thread.sleep(Delay.toMillis)
-            getSequence(baseURI, sequence)
+            if (waitUntilAvailable) {
+              logInfo(s"$sequence is not yet available, sleeping.")
+              Thread.sleep(Delay.toMillis)
+              getSequence(baseURI, sequence, waitUntilAvailable)
+            } else
+              throw e
         }
       case t: Throwable =>
-        logError(s"sequence $sequence caused an error", t)
-        Thread.sleep(Delay.toMillis)
-        getSequence(baseURI, sequence)
+        if (waitUntilAvailable) {
+          logError(s"sequence $sequence caused an error", t)
+          Thread.sleep(Delay.toMillis)
+          getSequence(baseURI, sequence)
+        } else
+          throw t
     }
   }
+
+  def getSequence(baseURI: URI, sequence: Int): Seq[AugmentedDiff] =
+    getSequence(baseURI, sequence, {(_: Int, _: RF) => ()}, true)
+
+  def getSequence(baseURI: URI, sequence: Int, waitUntilAvailable: Boolean): Seq[AugmentedDiff] =
+    getSequence(baseURI, sequence, {(_: Int, _: RF) => ()}, waitUntilAvailable)
+
+  def getSequence(baseURI: URI, sequence: Int, badGeometryHandler: (Int, RF) => Unit): Seq[AugmentedDiff] =
+    getSequence(baseURI, sequence, badGeometryHandler, true)
 
   @memoize(maxSize = 1, expiresAfter = 30 seconds)
   def getCurrentSequence(baseURI: URI): Option[Int] = {

--- a/src/main/scala/vectorpipe/sources/Source.scala
+++ b/src/main/scala/vectorpipe/sources/Source.scala
@@ -13,5 +13,6 @@ object Source {
   val StartSequence: String = "start_sequence"
   val EndSequence: String = "end_sequence"
 
+  val ErrorHandler: String = "error_handler"
   val ErrorCodes: Set[Int] = Set(403, 404)
 }

--- a/src/main/scala/vectorpipe/util/Implicits.scala
+++ b/src/main/scala/vectorpipe/util/Implicits.scala
@@ -1,0 +1,20 @@
+package vectorpipe.util
+
+import geotrellis.vector._
+import spray.json._
+
+import scala.reflect.ClassTag
+
+object Implicits extends Implicits
+
+trait Implicits extends RobustFeatureFormats {
+  implicit class RobustFeaturesToGeoJson[G <: Geometry: ClassTag, D: JsonWriter](features: Traversable[RobustFeature[G, D]]) {
+    def toGeoJson(): String = {
+      val fc = new JsonRobustFeatureCollection
+
+      features.foreach(fc.add(_))
+
+      fc.toJson.compactPrint
+    }
+  }
+}

--- a/src/main/scala/vectorpipe/util/JsonRobustFeatureCollection.scala
+++ b/src/main/scala/vectorpipe/util/JsonRobustFeatureCollection.scala
@@ -1,0 +1,57 @@
+package vectorpipe.util
+
+import geotrellis.vector._
+import geotrellis.vector.io._
+import spray.json._
+
+import scala.collection.immutable.VectorBuilder
+import scala.collection.mutable
+import scala.reflect.ClassTag
+import scala.util.{Try, Success, Failure}
+
+class JsonRobustFeatureCollection(features: List[JsValue] = Nil) {
+  private val buffer = mutable.ListBuffer(features: _*)
+
+  def add[G <: Geometry: ClassTag, D: JsonWriter](feature: RobustFeature[G, D]) =
+    buffer += RobustFeatureFormats.writeRobustFeatureJson(feature)
+
+  def getAll[F: JsonReader]: Vector[F] = {
+    val ret = new VectorBuilder[F]()
+    features.foreach{ f =>
+      Try(f.convertTo[F]) match {
+        case Success(feature) =>
+          ret += feature
+        case Failure(_: spray.json.DeserializationException) =>  //didn't match, live to fight another match
+        case Failure(e) => throw e // but bubble up other exceptions
+      }
+    }
+    ret.result()
+  }
+
+  def getAllGeometries(): Vector[Geometry] =
+    getAll[Point] ++ getAll[Line] ++ getAll[Polygon] ++
+      getAll[MultiPoint] ++ getAll[MultiLine] ++ getAll[MultiPolygon]
+
+  def toJson: JsValue = {
+    val bboxOption = getAllGeometries.map(_.envelope).reduceOption(_ combine _)
+    bboxOption match {
+      case Some(bbox) =>
+        JsObject(
+          "type" -> JsString("FeatureCollection"),
+          "bbox" -> ExtentListWriter.write(bbox),
+          "features" -> JsArray(buffer.toVector)
+        )
+      case _ =>
+        JsObject(
+          "type" -> JsString("FeatureCollection"),
+          "features" -> JsArray(buffer.toVector)
+        )
+    }
+  }
+}
+
+// object JsonRobustFeatureCollection {
+
+//   def apply() = new JsonRobustFeatureCollection
+
+//   def apply[G <: Geometry, D: JsonWriter]

--- a/src/main/scala/vectorpipe/util/JsonRobustFeatureCollectionMap.scala
+++ b/src/main/scala/vectorpipe/util/JsonRobustFeatureCollectionMap.scala
@@ -1,0 +1,54 @@
+package vectorpipe.util
+
+import geotrellis.vector._
+import geotrellis.vector.io._
+import spray.json._
+
+import scala.collection.mutable
+import scala.reflect.ClassTag
+import scala.util.{Try, Success, Failure}
+
+class JsonRobustFeatureCollectionMap(features: List[JsValue] = Nil) {
+  private val buffer = mutable.ListBuffer(features:_*)
+
+  def add[G <: Geometry: ClassTag, D: JsonWriter](featureMap: (String, RobustFeature[G, D])) =
+    buffer += RobustFeatureFormats.writeRobustFeatureJsonWithID(featureMap)
+
+  def toJson: JsValue = {
+    val bboxOption = getAll[Geometry].map(_._2.envelope).reduceOption(_ combine _)
+    bboxOption match {
+      case Some(bbox) =>
+        JsObject(
+          "type" -> JsString("FeatureCollection"),
+          "bbox" -> ExtentListWriter.write(bbox),
+          "features" -> JsArray(buffer.toVector)
+        )
+      case _ =>
+        JsObject(
+          "type" -> JsString("FeatureCollection"),
+          "features" -> JsArray(buffer.toVector)
+        )
+    }
+  }
+
+  private def getFeatureID(js: JsValue): String = {
+    js.asJsObject.getFields("id") match {
+      case Seq(JsString(id)) => id
+      case Seq(JsNumber(id)) => id.toString
+      case _ => throw new DeserializationException("Feature expected to have \"ID\" field")
+    }
+  }
+
+  def getAll[F :JsonReader]: Map[String, F] = {
+    var ret = Map[String, F]()
+    features.foreach{ f =>
+      Try(f.convertTo[F]) match {
+        case Success(feature) =>
+          ret += getFeatureID(f) -> feature
+        case Failure(_: spray.json.DeserializationException) =>  //didn't match, live to fight another match
+        case Failure(e) => throw e // but bubble up other exceptions
+      }
+    }
+    ret.toMap
+  }
+}

--- a/src/main/scala/vectorpipe/util/RobustFeature.scala
+++ b/src/main/scala/vectorpipe/util/RobustFeature.scala
@@ -1,0 +1,107 @@
+package vectorpipe.util
+
+import geotrellis.vector.io._
+import geotrellis.vector._
+import spray.json._
+
+import scala.reflect.{ClassTag, classTag}
+import scala.util.Try
+
+case class RobustFeature[+G <: Geometry: ClassTag, D](geom: Option[G], data: D) {
+  def toFeature(): Feature[G, D] = {
+    val g = geom match {
+      case Some(gg) => gg
+      // case x if classTag[Option[Line]].runtimeClass.isInstance(x) => Line(GeomFactory.factory.createLineString)
+      // case x if classTag[Option[Polygon]].runtimeClass.isInstance(x) => Polygon(GeomFactory.factory.createPolygon)
+      // case x if classTag[Option[MultiPoint]].runtimeClass.isInstance(x) => MultiPoint(GeomFactory.factory.createMultiPoint)
+      // case x if classTag[Option[MultiLine]].runtimeClass.isInstance(x) => MultiLine(GeomFactory.factory.createMultiLineString)
+      // case x if classTag[Option[MultiPolygon]].runtimeClass.isInstance(x) => MultiPolygon(GeomFactory.factory.createMultiPolygon)
+      case _ => MultiPoint.EMPTY
+    }
+    Feature(g.asInstanceOf[G], data)
+  }
+}
+
+trait RobustFeatureFormats {
+  def writeRobustFeatureJson[G <: Geometry: ClassTag, D: JsonWriter](obj: RobustFeature[G, D]): JsValue = {
+    val feature = obj.toFeature
+    JsObject(
+      "type" -> JsString("Feature"),
+      "geometry" -> GeometryFormat.write(feature.geom),
+      "bbox" -> ExtentListWriter.write(feature.envelope),
+      "properties" -> obj.data.toJson
+    )
+  }
+
+  def readRobustFeatureJson[D: JsonReader, G <: Geometry: JsonReader: ClassTag](value: JsValue): RobustFeature[G, D] = {
+    value.asJsObject.getFields("type", "geometry", "properties") match {
+      case Seq(JsString("Feature"), geom, data) =>
+        val g = Try(geom.convertTo[G]).toOption
+        val d = data.convertTo[D]
+        g match {
+          case Some(gg) if gg isEmpty => RobustFeature(None, d)
+          case _ => RobustFeature(g, d)
+        }
+      case _ => throw new DeserializationException("Feature expected")
+    }
+  }
+
+  def writeRobustFeatureJsonWithID[G <: Geometry: ClassTag, D: JsonWriter](idFeature: (String, RobustFeature[G, D])): JsValue = {
+    val feature = idFeature._2.toFeature
+    JsObject(
+      "type" -> JsString("Feature"),
+      "geometry" -> GeometryFormat.write(feature.geom),
+      "bbox" -> ExtentListWriter.write(feature.envelope),
+      "properties" -> idFeature._2.data.toJson,
+      "id" -> JsString(idFeature._1)
+    )
+  }
+
+  def readFeatureJsonWithID[D: JsonReader, G <: Geometry: JsonReader: ClassTag](value: JsValue): (String, RobustFeature[G, D]) = {
+    value.asJsObject.getFields("type", "geometry", "properties", "id") match {
+      case Seq(JsString("Feature"), geom, data, id) =>
+        val g = Try(geom.convertTo[G]).toOption
+        val d = data.convertTo[D]
+        val i = id.toString
+        g match {
+          case Some(gg) if gg isEmpty => (i, RobustFeature(None, d))
+          case _ => (i, RobustFeature(g, d))
+        }
+      case _ => throw new DeserializationException("Feature expected")
+    }
+  }
+
+  implicit def robustFeatureReader[G <: Geometry: JsonReader: ClassTag, D: JsonReader] = new RootJsonReader[RobustFeature[G, D]] {
+    override def read(json: JsValue): RobustFeature[G, D] =
+      readRobustFeatureJson[D, G](json)
+  }
+
+  implicit def robustFeatureWriter[G <: Geometry: JsonWriter: ClassTag, D: JsonWriter] = new RootJsonWriter[RobustFeature[G, D]] {
+    override def write(obj: RobustFeature[G, D]): JsValue = writeRobustFeatureJson(obj)
+  }
+
+  implicit def robustFeatureFormat[G <: Geometry: JsonFormat: ClassTag, D: JsonFormat] = new RootJsonFormat[RobustFeature[G, D]] {
+    override def read(json: JsValue): RobustFeature[G, D] =
+      readRobustFeatureJson[D, G](json)
+    override def write(obj: RobustFeature[G, D]): JsValue =
+      writeRobustFeatureJson(obj)
+  }
+
+  implicit object robustFeatureCollectionFormat extends RootJsonFormat[JsonRobustFeatureCollection] {
+    override def read(json: JsValue): JsonRobustFeatureCollection = json.asJsObject.getFields("type", "features") match {
+      case Seq(JsString("FeatureCollection"), JsArray(features)) => new JsonRobustFeatureCollection(features.toList)
+      case _ => throw new DeserializationException("FeatureCollection expected")
+    }
+    override def write(obj: JsonRobustFeatureCollection): JsValue = obj.toJson
+  }
+
+  implicit object robustFeatureCollectionMapFormat extends RootJsonFormat[JsonRobustFeatureCollectionMap] {
+    override def read(json: JsValue): JsonRobustFeatureCollectionMap = json.asJsObject.getFields("type", "features") match {
+      case Seq(JsString("FeatureCollection"), JsArray(features)) => new JsonRobustFeatureCollectionMap(features.toList)
+      case _ => throw new DeserializationException("FeatureCollection expected")
+    }
+    override def write(obj: JsonRobustFeatureCollectionMap): JsValue = obj.toJson
+  }
+}
+
+object RobustFeatureFormats extends RobustFeatureFormats with DefaultJsonProtocol


### PR DESCRIPTION
# Overview

While moving to https://github.com/azavea/onramp, it became necessary to handle diffs containing relations with faulty geometry, as Onramp will pass bad geometries through where Overpass will typically clean those geometries first.  This is useful as it allows one to see when bad relations are being created.

Additionally, we provide a means to plug in a error handler for when such bad geometries are encountered in the diff stream.

This PR is being opened against v1.1.0 due to a client still on the older version.  This PR will need to be brought forward into the v2 lineage, but will require a move to circe from spray.

## Checklist

- [x] Add entry to CHANGELOG.md 



