### PR TITLE
Use Github actions for CI

### DIFF
--- a/.github/docker-compose.yml
+++ b/.github/docker-compose.yml
@@ -1,0 +1,13 @@
+version: "3.7"
+
+services:
+  test:
+    image: openjdk:8-jdk
+    working_dir: /usr/local/src
+    command: ./sbt ++$SCALA_VERSION test
+    environment:
+      - CI
+      - SCALA_VERSION
+    volumes:
+      - ./../:/usr/local/src
+    network_mode: host

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on:
+  pull_request:
+    branches: ['**']
+  push:
+    branches: ['master']
+    tags: [v*]
+  # release:
+    # types: [published]
+
+jobs:
+  build:
+    name: Build and Test
+    strategy:
+      matrix:
+        scala: ["2.12.7"]
+    runs-on: ubuntu-latest
+
+    env:
+      SCALA_VERSION:  ${{ matrix.scala }}
+      BUILD_NUMBER:   ${{ github.run_id }}
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - uses: coursier/cache-action@v6
+      # - uses: olafurpg/setup-scala@v13
+        # with:
+          # java-version: adopt@1.8
+
+      - name: run tests
+        run: docker compose -f .github/docker-compose.yml up test --abort-on-container-exit --exit-code-from test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- GitHub actions config
+
 ### Changed
 
 ### Fixed


### PR DESCRIPTION
# Overview

This brief PR adds the machinery for using github actions to perform CI operations.

## Checklist

- [x] Add entry to CHANGELOG.md 

